### PR TITLE
feat: add --overwrite to rust2go-cli

### DIFF
--- a/examples/example-monoio-mem/build.rs
+++ b/examples/example-monoio-mem/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     rust2go::Builder::new()
         .with_go_src("./go")
-        // .with_regen("./src/user.rs", "./go/gen.go")
+        .with_regen("./src/user.rs", "./go/gen.go", false)
         .build();
 }

--- a/examples/example-monoio/build.rs
+++ b/examples/example-monoio/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     rust2go::Builder::new()
         .with_go_src("./go")
-        // .with_regen("./src/user.rs", "./go/gen.go")
+        .with_regen("./src/user.rs", "./go/gen.go", false)
         .build();
 }

--- a/examples/example-tokio-mem/build.rs
+++ b/examples/example-tokio-mem/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     rust2go::Builder::new()
         .with_go_src("./go")
-        // .with_regen("./src/user.rs", "./go/gen.go")
+        .with_regen("./src/user.rs", "./go/gen.go", false)
         .build();
 }

--- a/examples/example-tokio/build.rs
+++ b/examples/example-tokio/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     rust2go::Builder::new()
         .with_go_src("./go")
-        // .with_regen("./src/user.rs", "./go/gen.go")
+        .with_regen("./src/user.rs", "./go/gen.go", false)
         .build();
 }

--- a/rust2go-cli/src/lib.rs
+++ b/rust2go-cli/src/lib.rs
@@ -1,4 +1,4 @@
-use std::io::Cursor;
+use std::{io::Cursor, path::PathBuf};
 
 use clap::Parser;
 use rust2go_common::raw_file::RawRsFile;
@@ -8,11 +8,11 @@ use rust2go_common::raw_file::RawRsFile;
 pub struct Args {
     /// Path of source rust file
     #[arg(short, long)]
-    pub src: String,
+    pub src: PathBuf,
 
     /// Path of destination go file
     #[arg(short, long)]
-    pub dst: String,
+    pub dst: PathBuf,
 
     /// With or without go main function
     #[arg(long, default_value = "false")]
@@ -25,9 +25,18 @@ pub struct Args {
     /// Disable auto format go file
     #[arg(long, default_value = "false")]
     pub no_fmt: bool,
+
+    /// Whether or not overwrite the destination go file if existing
+    #[arg(long, default_value = "true")]
+    pub overwrite: bool,
 }
 
 pub fn generate(args: &Args) {
+    if !args.overwrite && args.dst.is_file() {
+        println!("destination file exists, aborting. use --overwrite=true to regenerate the file");
+        return;
+    }
+
     // Read and parse rs file.
     let file_content = std::fs::read_to_string(&args.src).expect("Unable to read file");
     let raw_file = RawRsFile::new(file_content);

--- a/rust2go/src/build.rs
+++ b/rust2go/src/build.rs
@@ -95,9 +95,15 @@ impl<GOSRC, GOC> Builder<GOSRC, GOC> {
     /// Regenerate go code.
     /// Note: you should generate go code before build with rust2go-cli.
     /// This function is to make sure the go code is updated.
-    pub fn with_regen(mut self, src: &str, dst: &str) -> Self {
-        self.regen_arg.src = src.to_string();
-        self.regen_arg.dst = dst.to_string();
+    pub fn with_regen(
+        mut self,
+        src: impl Into<PathBuf>,
+        dst: impl Into<PathBuf>,
+        overwrite: bool,
+    ) -> Self {
+        self.regen_arg.src = src.into();
+        self.regen_arg.dst = dst.into();
+        self.regen_arg.overwrite = overwrite;
         self
     }
 
@@ -219,7 +225,7 @@ impl<GOC: GoCompiler> Builder<PathBuf, GOC> {
             .as_deref()
             .unwrap_or(crate::DEFAULT_BINDING_FILE);
         // Regenerate go code.
-        if !self.regen_arg.src.is_empty() && !self.regen_arg.dst.is_empty() {
+        if self.regen_arg.src.is_file() {
             rust2go_cli::generate(&self.regen_arg);
         }
         self.go_comp

--- a/test/build.rs
+++ b/test/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     rust2go::Builder::new()
         .with_go_src("./go")
-        // .with_regen("./src/user.rs", "./go/gen.go")
+        .with_regen("./src/user.rs", "./go/gen.go", false)
         .build();
 }


### PR DESCRIPTION
This PR adds `--overwrite` to `rust2go-cli` and changes `Builder::with_regen` to accept an extra `overwrite` parameter. So that the `// with_regen` lines in all examples can be uncommented.  Please let me know you feedback, thanks!