### PR TITLE
fix: parameterless function with non-unit return does not compile

### DIFF
--- a/rust2go-common/src/raw_file.rs
+++ b/rust2go-common/src/raw_file.rs
@@ -1488,7 +1488,7 @@ inline void {fn_name}_cb(const void *f_ptr, {c_resp_type} resp, const void *slot
                             let (_buf, #func_param_names) = ::rust2go::ToRef::calc_ref(#ref_marks #func_param_names);
                         )*
                         #[allow(clippy::useless_transmute)]
-                        unsafe { #path_prefix #c_func_name(#(::std::mem::transmute(#func_param_names)),*, &slot as *const _ as *const () as *mut _, Self::#callback_name as *const () as *mut _) };
+                        unsafe { #path_prefix #c_func_name(#(::std::mem::transmute(#func_param_names),)* &slot as *const _ as *const () as *mut _, Self::#callback_name as *const () as *mut _) };
                         slot.take().unwrap()
                     }
                 });


### PR DESCRIPTION
This PR fixes an issue that a parameterless function with non-unit return in the rust trait(e.g. `fn demo_get_n() -> i32;`) does not compile. The changes to examples that verify this change are made in https://github.com/ihciah/rust2go/pull/10

```
error: expected expression, found `,`
```