### PR TITLE
chore: bump crate versions to prepare for publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.14"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d2eb3cd3d1bf4529e31c215ee6f93ec5a3d536d9f578f93d9d33ee19562932"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "shlex",
 ]
@@ -420,9 +420,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -661,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.3"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -777,7 +777,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rust2go"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "bindgen",
  "rust2go-cli",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "rust2go-cli"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "cbindgen",
  "clap",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "rust2go-common"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -842,9 +842,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -963,9 +963,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.76"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1004,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",

--- a/rust2go-cli/Cargo.toml
+++ b/rust2go-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust2go-cli"
-version = "0.3.8"
+version = "0.3.9"
 
 description = "Rust2go commandline tool."
 
@@ -12,7 +12,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-rust2go-common = { version = "0.3.10", path = "../rust2go-common" }
+rust2go-common = { version = "0.3.11", path = "../rust2go-common" }
 
 clap = { version = "4", features = ["derive"] }
 cbindgen = { version = "0.27", default-features = false }

--- a/rust2go-common/Cargo.toml
+++ b/rust2go-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust2go-common"
-version = "0.3.10"
+version = "0.3.11"
 
 description = "Rust2go common library."
 

--- a/rust2go-macro/Cargo.toml
+++ b/rust2go-macro/Cargo.toml
@@ -16,7 +16,7 @@ repository.workspace = true
 proc-macro = true
 
 [dependencies]
-rust2go-common = { version = "0.3.9", path = "../rust2go-common" }
+rust2go-common = { version = "0.3.11", path = "../rust2go-common" }
 
 proc-macro2 = { version = "1" }
 quote = { version = "1" }

--- a/rust2go/Cargo.toml
+++ b/rust2go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust2go"
-version = "0.3.15"
+version = "0.3.16"
 
 description = "Rust2go main shared library."
 
@@ -14,7 +14,7 @@ repository.workspace = true
 [dependencies]
 rust2go-macro = { version = "0.3.9", path = "../rust2go-macro" }
 rust2go-convert = { version = "0.1.0", path = "../rust2go-convert" }
-rust2go-cli = { version = "0.3.8", path = "../rust2go-cli", optional = true }
+rust2go-cli = { version = "0.3.9", path = "../rust2go-cli", optional = true }
 
 bindgen = { version = "0.70", optional = true }
 syn = { version = "2", features = ["full"], optional = true }


### PR DESCRIPTION
This PR bumps versions of the crates that receive changes in #11 #12 and #13 
@ihciah could you please cut a release and publish `rust2go`, `rust2go-common` and `rust2go-cli` to crates.io? Thanks!
