### PR TITLE
chore: bump rust2go-macro version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ version = "0.1.0"
 
 [[package]]
 name = "rust2go-macro"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust2go-macro/Cargo.toml
+++ b/rust2go-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust2go-macro"
-version = "0.3.9"
+version = "0.3.10"
 
 description = "Rust2go macro."
 

--- a/rust2go/Cargo.toml
+++ b/rust2go/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-rust2go-macro = { version = "0.3.9", path = "../rust2go-macro" }
+rust2go-macro = { version = "0.3.10", path = "../rust2go-macro" }
 rust2go-convert = { version = "0.1.0", path = "../rust2go-convert" }
 rust2go-cli = { version = "0.3.9", path = "../rust2go-cli", optional = true }
 


### PR DESCRIPTION
Hi @ihciah I missed `rust2go-macro` in https://github.com/ihciah/rust2go/pull/18
Could you please publish `rust2go-macro` as well after this being merged. Thanks!