### PR TITLE
fix: typos in docs

### DIFF
--- a/asmcall/README.md
+++ b/asmcall/README.md
@@ -8,7 +8,7 @@ To avoid extensive checks, scheduling, and GC synchronization overhead, replacin
 
 This package provides four functions (corresponding to 0~3 arguments). Handwritten assembly is used for Go stack switching and ABI conversion on AMD64 and ARM64 platforms. For other platforms, it falls back to a CGO implementation.
 
-[fastcgo](https://github.com/petermattis/fastcgo) and [rustgo](https://words.filippo.io/rustgo/) were the first attempt at a similar optimization. Implemented seven years ago, it is no longer compatible with newer versions of the Go compiler. Drawing inspiration from fastcgo and refering to the Go runtime source code, I made a new implementation. The main differences include how the g pointer is switched, avoidance of asynchronous preemption, and added ARM64 assembly support.
+[fastcgo](https://github.com/petermattis/fastcgo) and [rustgo](https://words.filippo.io/rustgo/) were the first attempt at a similar optimization. Implemented seven years ago, it is no longer compatible with newer versions of the Go compiler. Drawing inspiration from fastcgo and referring to the Go runtime source code, I made a new implementation. The main differences include how the g pointer is switched, avoidance of asynchronous preemption, and added ARM64 assembly support.
 
 Core Principles:
 

--- a/docs/trait-attrs.md
+++ b/docs/trait-attrs.md
@@ -6,8 +6,8 @@ author: ihciah
 
 Now rust2go supports 3 attributes on trait's async function:
 1. `#[send]`: the function will be generated as `impl Future<Output=..> + Send + Sync`. Use it when you need it.
-2. `#[drop_safe]`: this makes the function safe, but requires all paramters passing ownership. Use it when you cannot make sure the future may cancel.
-3. `#[drop_safe_ret]`: to make the function safe, it requires passing ownership; this attribute allow users to get the paramters ownership back. Use it when you cannot make sure the future may cancel, and you want to get back the parameters ownership after the calling.
+2. `#[drop_safe]`: this makes the function safe, but requires all parameters passing ownership. Use it when you cannot make sure the future may cancel.
+3. `#[drop_safe_ret]`: to make the function safe, it requires passing ownership; this attribute allow users to get the parameters ownership back. Use it when you cannot make sure the future may cancel, and you want to get back the parameters ownership after the calling.
 4. `#[mem]` or `#[shm]`: make this function implemented based on shared memory, whose performance is highly improved(but it requires unix now). Unless you find obvious performance bottlenecks, there is no need to enable it.
 5. `#[go_pass_struct]`: make the generated go side code use pointer instead of value at parameters. This is useful when the parameter is large. This does not affect the rust side code. It is not recommended to enable this unless you explicitly want to pass the structure itself.
 6. `#[cgo_callback]`: make the generated go side code use CGO based method instead of ASM. It is not recommended to enable it unless you find some failures caused by ASMCALL.

--- a/test/README.md
+++ b/test/README.md
@@ -1,2 +1,2 @@
-# Rust2Go Intergrated Test
+# Rust2Go Integrated Test
 


### PR DESCRIPTION
This pull request includes several documentation updates to improve clarity and fix typos. The most important changes are corrections in the `asmcall/README.md` and `docs/trait-attrs.md` files, as well as a minor fix in the `test/README.md` file.

Documentation updates:

* [`asmcall/README.md`](diffhunk://#diff-dd9c8f443eee4077961665515ae7f4df78d3543fbdfc596a20083939909284f4L11-R11): Corrected a typo from "refering" to "referring."
* [`docs/trait-attrs.md`](diffhunk://#diff-b9314a2986a3461f2a57ec8f397c018e1da846ae1649a8db6bda26d8b31d77caL9-R10): Fixed typos in the descriptions of the `#[drop_safe]` and `#[drop_safe_ret]` attributes.
* [`test/README.md`](diffhunk://#diff-5de36acd90308dc62abf7855a686ee7052ffb6e762c756fd735fb0c9fbd9595dL1-R1): Corrected a typo in the title from "Intergrated" to "Integrated."