### PR TITLE
[👀🌊👋💦]upgrade sccache to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.6
+        uses: mozilla-actions/sccache-action@v0.0.9
         timeout-minutes: 5
         continue-on-error: true
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.6
+        uses: mozilla-actions/sccache-action@v0.0.9
         timeout-minutes: 5
         continue-on-error: true
       - uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
This PR aimed to fix the recent CI failure. The CI failure is due to an issue with `sccache`, which is no longer functional because its legacy service has been shut down as of April 15,2025.