### PR TITLE
fix: apply address operator to all params in mem_call functions

### DIFF
--- a/rust2go-common/src/r2g.rs
+++ b/rust2go-common/src/r2g.rs
@@ -380,12 +380,12 @@ impl R2GFnRepr {
             }
             fn_body.push_str("pool.Submit(func() {\n");
             fn_body.push_str(&format!(
-                "resp := {trait_name}Impl.{fn_name}({ref_mark}{params})\n",
+                "resp := {trait_name}Impl.{fn_name}({params})\n",
                 fn_name = self.name,
                 params = self
                     .params
                     .iter()
-                    .map(|p| format!("{}_", p.name))
+                    .map(|p| format!("{ref_mark}{}_", p.name))
                     .collect::<Vec<_>>()
                     .join(", ")
             ));

--- a/test/go/impl.go
+++ b/test/go/impl.go
@@ -160,3 +160,15 @@ func valid_token(token []uint8) bool {
 	}
 	return true
 }
+
+func (d *Demo) multi_param_test(user *User, message *string, token *[]uint8) LoginResponse {
+	// Test implementation for multi-parameter function
+	// This tests that all parameters are correctly passed with & prefix
+	fmt.Printf("[go] multi_param_test called with user: %+v, message: %s, token: %v\n", user, *message, *token)
+
+	return LoginResponse{
+		succ:    true,
+		message: fmt.Sprintf("Received user %s with message: %s", user.name, *message),
+		token:   *token,
+	}
+}

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -343,4 +343,22 @@ mod tests {
             age: 0,
         });
     }
+
+    #[monoio::test(timer_enabled = true)]
+    async fn test_multi_param_function() {
+        // Test function with multiple parameters to ensure all parameters get & prefix
+        let user = User {
+            id: 1,
+            name: "test_user".to_string(),
+            age: 25,
+        };
+        let message = "test message".to_string();
+        let token = vec![1, 2, 3, 4, 5];
+
+        let response = unsafe { TestCallImpl::multi_param_test(&user, &message, &token).await };
+
+        // Verify the response (implementation will be provided by Go side)
+        // For now, we just ensure the function can be called without panic
+        assert!(!response.message.is_empty());
+    }
 }

--- a/test/src/user.rs
+++ b/test/src/user.rs
@@ -54,6 +54,7 @@ pub struct PMFriendResponse {
 }
 
 #[rust2go::r2g]
+#[allow(clippy::ptr_arg)]
 pub trait TestCall {
     #[go_pass_struct]
     fn ping(n: usize) -> usize;
@@ -64,4 +65,6 @@ pub trait TestCall {
     async fn delete_friends(req: FriendsListRequest) -> FriendsListResponse;
     #[drop_safe_ret]
     async fn pm_friend(req: PMFriendRequest) -> PMFriendResponse;
+    #[mem_call]
+    async fn multi_param_test(user: &User, message: &String, token: &Vec<u8>) -> LoginResponse;
 }


### PR DESCRIPTION
Fixes #88 and add a unit test

* `rust2go-common/src/r2g.rs`: Modified the `R2GFnRepr` implementation to ensure parameters are prefixed with `&` when passed to Go functions. This aligns with the expected behavior for reference parameters in cross-language calls.
* `test/src/lib.rs`: Added an asynchronous test function `test_multi_param_function` to validate the handling of multiple parameters with `&` prefixes. This ensures compatibility and correctness in cross-language function calls.
* `test/src/user.rs`: Extended the `TestCall` trait to include a new asynchronous function `multi_param_test`, which accepts multiple parameters (user, message, and token) passed by reference.
* `test/go/impl.go`: Added a Go implementation for the `multi_param_test` function to handle multiple parameters and return a `LoginResponse`. This provides a testable implementation for cross-language integration.