### PR TITLE
fix: lint error

### DIFF
--- a/rust2go-common/src/common.rs
+++ b/rust2go-common/src/common.rs
@@ -405,7 +405,7 @@ typedef struct QueueMeta {
                 // }
                 Item::Struct(s) => {
                     let struct_name = s.ident.to_string();
-                    out.push_str(&format!("type {} struct {{\n", struct_name));
+                    out.push_str(&format!("type {struct_name} struct {{\n"));
                     for field in s.fields.iter() {
                         let field_name = field
                             .ident

--- a/rust2go-common/src/r2g.rs
+++ b/rust2go-common/src/r2g.rs
@@ -416,7 +416,7 @@ impl R2GFnRepr {
             let new_name = format_ident!("_new_{}", p.name);
             let cvt = p.ty.c_to_go_field_converter(levels).0;
             new_cvt.push_str(&format!("{new_name} := {cvt}({})\n", p.name));
-            new_names.push(format!("{ref_mark}{}", new_name));
+            new_names.push(format!("{ref_mark}{new_name}"));
         }
         match (self.is_async, &self.ret) {
             (true, None) => panic!("async function must have a return value"),

--- a/test/go/gen.go
+++ b/test/go/gen.go
@@ -78,6 +78,7 @@ type TestCall interface {
 	add_friends(req *FriendsListRequest) FriendsListResponse
 	delete_friends(req *FriendsListRequest) FriendsListResponse
 	pm_friend(req *PMFriendRequest) PMFriendResponse
+	multi_param_test(user *User, message *string, token *[]uint8) LoginResponse
 }
 
 //export CTestCall_ping
@@ -140,6 +141,21 @@ func CTestCall_pm_friend(req C.PMFriendRequestRef, slot *C.void, cb *C.void) {
 	go func() {
 		resp := TestCallImpl.pm_friend(&_new_req)
 		resp_ref, buffer := cvt_ref(cntPMFriendResponse, refPMFriendResponse)(&resp)
+		asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+		runtime.KeepAlive(resp_ref)
+		runtime.KeepAlive(resp)
+		runtime.KeepAlive(buffer)
+	}()
+}
+
+//export CTestCall_multi_param_test
+func CTestCall_multi_param_test(user C.UserRef, message C.StringRef, token C.ListRef, slot *C.void, cb *C.void) {
+	_new_user := newUser(user)
+	_new_message := newString(message)
+	_new_token := new_list_mapper_primitive(newC_uint8_t)(token)
+	go func() {
+		resp := TestCallImpl.multi_param_test(&_new_user, &_new_message, &_new_token)
+		resp_ref, buffer := cvt_ref(cntLoginResponse, refLoginResponse)(&resp)
 		asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
 		runtime.KeepAlive(resp_ref)
 		runtime.KeepAlive(resp)


### PR DESCRIPTION
### Code formatting improvements:
* Updated Rust string formatting to use inline formatting for better readability in `rust2go-common/src/common.rs` and `rust2go-common/src/r2g.rs`.