### PR TITLE
Treat `Option<T>` as `Vec<T>`

### DIFF
--- a/rust2go-common/src/common.rs
+++ b/rust2go-common/src/common.rs
@@ -536,7 +536,7 @@ typedef struct QueueMeta {
         fn type_to_node(ty: &Type) -> Result<Node> {
             let seg = type_to_segment(ty)?;
             match seg.ident.to_string().as_str() {
-                "Vec" => {
+                "Vec" | "Option" => {
                     let inside = match &seg.arguments {
                         syn::PathArguments::AngleBracketed(ga) => match ga.args.last().unwrap() {
                             syn::GenericArgument::Type(ty) => ty,
@@ -658,7 +658,7 @@ impl TryFrom<&Type> for ParamType {
                 }
                 ParamTypeInner::Primitive(seg.ident.clone())
             }
-            "Vec" => ParamTypeInner::List(ty.clone()),
+            "Vec" | "Option" => ParamTypeInner::List(ty.clone()),
             _ => {
                 if !seg.arguments.is_none() {
                     sbail!("custom types with arguments are not supported")

--- a/rust2go-convert/src/convert.rs
+++ b/rust2go-convert/src/convert.rs
@@ -176,6 +176,47 @@ impl<T: FromRef> FromRef for Vec<T> {
     }
 }
 
+// Owned to Ref
+// Option<T> -> ListRef
+impl<T: ToRef> ToRef for Option<T> {
+    const MEM_TYPE: MemType = T::MEM_TYPE.next();
+    type Ref = ListRef;
+
+    fn to_size(&self, acc: &mut usize) {
+        if matches!(Self::MEM_TYPE, MemType::Complex) {
+            *acc += self.as_slice().len() * std::mem::size_of::<T::Ref>();
+            self.iter().for_each(|elem| elem.to_size(acc));
+        }
+    }
+
+    fn to_ref(&self, writer: &mut Writer) -> Self::Ref {
+        let slice = self.as_slice();
+        let mut data = ListRef(DataView::new(slice.as_ptr(), slice.len()));
+
+        if matches!(Self::MEM_TYPE, MemType::Complex) {
+            data.0.ptr = writer.as_ptr().cast();
+            unsafe {
+                let mut children = writer.reserve(slice.len() * std::mem::size_of::<T::Ref>());
+                self.iter()
+                    .for_each(|elem| children.put(ToRef::to_ref(elem, writer)));
+            }
+        }
+        data
+    }
+}
+
+impl<T: FromRef> FromRef for Option<T> {
+    type Ref = ListRef;
+
+    fn from_ref(ref_: &Self::Ref) -> Self {
+        if ref_.0.len == 0 {
+            return None;
+        }
+        let slice = unsafe { std::slice::from_raw_parts(ref_.0.ptr.cast(), ref_.0.len) };
+        slice.iter().map(FromRef::from_ref).next()
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 #[repr(transparent)]
 pub struct StringRef(DataView);

--- a/rust2go-macro/src/lib.rs
+++ b/rust2go-macro/src/lib.rs
@@ -32,7 +32,7 @@ pub fn r2g_derive(input: TokenStream) -> TokenStream {
             return TokenStream::default();
         };
         match first_seg.ident.to_string().as_str() {
-            "Vec" => {
+            "Vec" | "Option" => {
                 ref_fields.push(quote! {#name: ::rust2go::ListRef});
             }
             "String" => {

--- a/test/go/impl.go
+++ b/test/go/impl.go
@@ -149,6 +149,14 @@ func (d *Demo) pm_friend(req *PMFriendRequest) PMFriendResponse {
 	}
 }
 
+func (d *Demo) optional_test(optional *Optional) Optional {
+	fmt.Printf("[go] optional_test called with optional: %+v\n", optional.optional)
+
+	return Optional{
+		optional: optional.optional,
+	}
+}
+
 func valid_token(token []uint8) bool {
 	if len(token) != 3 {
 		return false

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -361,4 +361,17 @@ mod tests {
         // For now, we just ensure the function can be called without panic
         assert!(!response.message.is_empty());
     }
+
+    #[monoio::test(timer_enabled = true)]
+    async fn test_optional() {
+        let req = Optional { optional: None };
+        let res = TestCallImpl::optional_test(req);
+        assert_eq!(res.optional, None);
+
+        let req = Optional {
+            optional: Some("yes".to_string()),
+        };
+        let res = TestCallImpl::optional_test(req);
+        assert_eq!(res.optional, Some("yes".to_string()));
+    }
 }

--- a/test/src/user.rs
+++ b/test/src/user.rs
@@ -53,6 +53,11 @@ pub struct PMFriendResponse {
     pub message: String,
 }
 
+#[derive(rust2go::R2G, Clone)]
+pub struct Optional {
+    pub optional: Option<String>,
+}
+
 #[rust2go::r2g]
 #[allow(clippy::ptr_arg)]
 pub trait TestCall {
@@ -67,4 +72,5 @@ pub trait TestCall {
     async fn pm_friend(req: PMFriendRequest) -> PMFriendResponse;
     #[mem_call]
     async fn multi_param_test(user: &User, message: &String, token: &Vec<u8>) -> LoginResponse;
+    fn optional_test(optional: Optional) -> Optional;
 }


### PR DESCRIPTION
Naive implementation of the `Option` handling, as a regular slice of length either 0 or 1. This implementation allows to pass more complex structures with optional values, where golang treats such as a `[]T` type objects. 
