### PR TITLE
feat(macro): Preserve attribute macros on structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,7 @@ dependencies = [
 name = "rust2go-common"
 version = "0.4.0"
 dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",

--- a/rust2go-common/Cargo.toml
+++ b/rust2go-common/Cargo.toml
@@ -15,3 +15,4 @@ repository.workspace = true
 syn = { version = "2", features = ["full"] }
 quote = { version = "1" }
 proc-macro2 = { version = "1" }
+heck ="0.5.0"

--- a/rust2go-common/src/common.rs
+++ b/rust2go-common/src/common.rs
@@ -2,8 +2,8 @@
 
 use crate::{g2r::G2RTraitRepr, r2g::R2GTraitRepr};
 use heck::{
-    ToKebabCase, ToLowerCamelCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase,
-    ToTitleCase, ToTrainCase, ToUpperCamelCase
+    ToKebabCase, ToLowerCamelCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase, ToTitleCase,
+    ToTrainCase, ToUpperCamelCase,
 };
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote, ToTokens};

--- a/rust2go-macro/src/lib.rs
+++ b/rust2go-macro/src/lib.rs
@@ -133,6 +133,15 @@ pub fn r2g(attrs: TokenStream, item: TokenStream) -> TokenStream {
         .unwrap_or_else(|e| TokenStream::from(e.to_compile_error()))
 }
 
+/// Mark only
+#[proc_macro_attribute]
+pub fn r2g_struct_tag(_attrs: TokenStream, item: TokenStream) -> TokenStream {
+    let input_struct = parse_macro_input!(item as syn::DeriveInput);
+    TokenStream::from(quote! {
+        #input_struct
+    })
+}
+
 #[proc_macro_attribute]
 pub fn g2r(_attrs: TokenStream, item: TokenStream) -> TokenStream {
     syn::parse::<syn::ItemTrait>(item)

--- a/rust2go-macro/src/lib.rs
+++ b/rust2go-macro/src/lib.rs
@@ -17,6 +17,7 @@ pub fn r2g_derive(input: TokenStream) -> TokenStream {
         syn::Data::Struct(d) => d,
         _ => return TokenStream::default(),
     };
+    let attrs = input.attrs;
     let type_name = input.ident;
     let type_name_str = type_name.to_string();
 
@@ -57,6 +58,7 @@ pub fn r2g_derive(input: TokenStream) -> TokenStream {
     }
 
     let expanded = quote! {
+        #(#attrs)*
         #[repr(C)]
         pub struct #ref_type_name {
             #(#ref_fields),*

--- a/rust2go-macro/src/lib.rs
+++ b/rust2go-macro/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 ihciah. All Rights Reserved.
 
 use proc_macro::TokenStream;
-use quote::{format_ident, quote, ToTokens};
+use quote::{format_ident, quote};
 use rust2go_common::{g2r::G2RTraitRepr, r2g::R2GTraitRepr, sbail};
 use syn::{parse::Parser, parse_macro_input, DeriveInput, Ident};
 

--- a/rust2go-macro/src/lib.rs
+++ b/rust2go-macro/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 ihciah. All Rights Reserved.
 
 use proc_macro::TokenStream;
-use quote::{format_ident, quote};
+use quote::{format_ident, quote, ToTokens};
 use rust2go_common::{g2r::G2RTraitRepr, r2g::R2GTraitRepr, sbail};
 use syn::{parse::Parser, parse_macro_input, DeriveInput, Ident};
 
@@ -136,10 +136,7 @@ pub fn r2g(attrs: TokenStream, item: TokenStream) -> TokenStream {
 /// Mark only
 #[proc_macro_attribute]
 pub fn r2g_struct_tag(_attrs: TokenStream, item: TokenStream) -> TokenStream {
-    let input_struct = parse_macro_input!(item as syn::DeriveInput);
-    TokenStream::from(quote! {
-        #input_struct
-    })
+    item
 }
 
 #[proc_macro_attribute]

--- a/rust2go/src/lib.rs
+++ b/rust2go/src/lib.rs
@@ -12,7 +12,7 @@ pub use slot::{new_atomic_slot, SlotReader, SlotWriter};
 mod future;
 pub use future::{ResponseFuture, ResponseFutureWithoutReq};
 
-pub use rust2go_macro::{g2r, r2g, R2G};
+pub use rust2go_macro::{g2r, r2g, r2g_struct_tag, R2G};
 
 pub const DEFAULT_BINDING_FILE: &str = "_go_bindings.rs";
 #[macro_export]

--- a/test/go/gen.go
+++ b/test/go/gen.go
@@ -71,542 +71,575 @@ typedef struct PreserveStructAttrsResponseRef {
 */
 import "C"
 import (
-"unsafe"
-"runtime"
-"reflect"
+	"reflect"
+	"runtime"
+	"unsafe"
 
-"github.com/ihciah/rust2go/asmcall"
+	"github.com/ihciah/rust2go/asmcall"
 )
+
 var TestCallImpl TestCall
+
 type TestCall interface {
-ping(n uint) uint
-login(req *LoginRequest) LoginResponse
-logout(req *User) 
-add_friends(req *FriendsListRequest) FriendsListResponse
-delete_friends(req *FriendsListRequest) FriendsListResponse
-pm_friend(req *PMFriendRequest) PMFriendResponse
-multi_param_test(user *User, message *string, token *[]uint8) LoginResponse
-preserve_struct_attrs_test(data *PreserveStructAttrsRequest) PreserveStructAttrsResponse
+	ping(n uint) uint
+	login(req *LoginRequest) LoginResponse
+	logout(req *User)
+	add_friends(req *FriendsListRequest) FriendsListResponse
+	delete_friends(req *FriendsListRequest) FriendsListResponse
+	pm_friend(req *PMFriendRequest) PMFriendResponse
+	multi_param_test(user *User, message *string, token *[]uint8) LoginResponse
+	preserve_struct_attrs_test(data *PreserveStructAttrsRequest) PreserveStructAttrsResponse
 }
+
 //export CTestCall_ping
 func CTestCall_ping(n C.uintptr_t, slot *C.void, cb *C.void) {
-_new_n := newC_uintptr_t(n)
-resp := TestCallImpl.ping(_new_n)
-resp_ref, buffer := cvt_ref(cntC_uintptr_t, refC_uintptr_t)(&resp)
-asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
-runtime.KeepAlive(resp_ref)
-runtime.KeepAlive(resp)
-runtime.KeepAlive(buffer)
+	_new_n := newC_uintptr_t(n)
+	resp := TestCallImpl.ping(_new_n)
+	resp_ref, buffer := cvt_ref(cntC_uintptr_t, refC_uintptr_t)(&resp)
+	asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+	runtime.KeepAlive(resp_ref)
+	runtime.KeepAlive(resp)
+	runtime.KeepAlive(buffer)
 }
+
 //export CTestCall_login
 func CTestCall_login(req C.LoginRequestRef, slot *C.void, cb *C.void) {
-_new_req := newLoginRequest(req)
-resp := TestCallImpl.login(&_new_req)
-resp_ref, buffer := cvt_ref(cntLoginResponse, refLoginResponse)(&resp)
-asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
-runtime.KeepAlive(resp_ref)
-runtime.KeepAlive(resp)
-runtime.KeepAlive(buffer)
+	_new_req := newLoginRequest(req)
+	resp := TestCallImpl.login(&_new_req)
+	resp_ref, buffer := cvt_ref(cntLoginResponse, refLoginResponse)(&resp)
+	asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+	runtime.KeepAlive(resp_ref)
+	runtime.KeepAlive(resp)
+	runtime.KeepAlive(buffer)
 }
+
 //export CTestCall_logout
-func CTestCall_logout(req C.UserRef, ) {
-_new_req := newUser(req)
-    TestCallImpl.logout(&_new_req)
+func CTestCall_logout(req C.UserRef) {
+	_new_req := newUser(req)
+	TestCallImpl.logout(&_new_req)
 }
+
 //export CTestCall_add_friends
 func CTestCall_add_friends(req C.FriendsListRequestRef, slot *C.void, cb *C.void) {
-_new_req := newFriendsListRequest(req)
-    go func() {
-resp := TestCallImpl.add_friends(&_new_req)
-resp_ref, buffer := cvt_ref(cntFriendsListResponse, refFriendsListResponse)(&resp)
-asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
-runtime.KeepAlive(resp_ref)
-runtime.KeepAlive(resp)
-runtime.KeepAlive(buffer)
-}()
+	_new_req := newFriendsListRequest(req)
+	go func() {
+		resp := TestCallImpl.add_friends(&_new_req)
+		resp_ref, buffer := cvt_ref(cntFriendsListResponse, refFriendsListResponse)(&resp)
+		asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+		runtime.KeepAlive(resp_ref)
+		runtime.KeepAlive(resp)
+		runtime.KeepAlive(buffer)
+	}()
 }
+
 //export CTestCall_delete_friends
 func CTestCall_delete_friends(req C.FriendsListRequestRef, slot *C.void, cb *C.void) {
-_new_req := newFriendsListRequest(req)
-    go func() {
-resp := TestCallImpl.delete_friends(&_new_req)
-resp_ref, buffer := cvt_ref(cntFriendsListResponse, refFriendsListResponse)(&resp)
-asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
-runtime.KeepAlive(resp_ref)
-runtime.KeepAlive(resp)
-runtime.KeepAlive(buffer)
-}()
+	_new_req := newFriendsListRequest(req)
+	go func() {
+		resp := TestCallImpl.delete_friends(&_new_req)
+		resp_ref, buffer := cvt_ref(cntFriendsListResponse, refFriendsListResponse)(&resp)
+		asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+		runtime.KeepAlive(resp_ref)
+		runtime.KeepAlive(resp)
+		runtime.KeepAlive(buffer)
+	}()
 }
+
 //export CTestCall_pm_friend
 func CTestCall_pm_friend(req C.PMFriendRequestRef, slot *C.void, cb *C.void) {
-_new_req := newPMFriendRequest(req)
-    go func() {
-resp := TestCallImpl.pm_friend(&_new_req)
-resp_ref, buffer := cvt_ref(cntPMFriendResponse, refPMFriendResponse)(&resp)
-asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
-runtime.KeepAlive(resp_ref)
-runtime.KeepAlive(resp)
-runtime.KeepAlive(buffer)
-}()
+	_new_req := newPMFriendRequest(req)
+	go func() {
+		resp := TestCallImpl.pm_friend(&_new_req)
+		resp_ref, buffer := cvt_ref(cntPMFriendResponse, refPMFriendResponse)(&resp)
+		asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+		runtime.KeepAlive(resp_ref)
+		runtime.KeepAlive(resp)
+		runtime.KeepAlive(buffer)
+	}()
 }
+
 //export CTestCall_multi_param_test
 func CTestCall_multi_param_test(user C.UserRef, message C.StringRef, token C.ListRef, slot *C.void, cb *C.void) {
-_new_user := newUser(user)
-_new_message := newString(message)
-_new_token := new_list_mapper_primitive(newC_uint8_t)(token)
-    go func() {
-resp := TestCallImpl.multi_param_test(&_new_user, &_new_message, &_new_token)
-resp_ref, buffer := cvt_ref(cntLoginResponse, refLoginResponse)(&resp)
-asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
-runtime.KeepAlive(resp_ref)
-runtime.KeepAlive(resp)
-runtime.KeepAlive(buffer)
-}()
+	_new_user := newUser(user)
+	_new_message := newString(message)
+	_new_token := new_list_mapper_primitive(newC_uint8_t)(token)
+	go func() {
+		resp := TestCallImpl.multi_param_test(&_new_user, &_new_message, &_new_token)
+		resp_ref, buffer := cvt_ref(cntLoginResponse, refLoginResponse)(&resp)
+		asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+		runtime.KeepAlive(resp_ref)
+		runtime.KeepAlive(resp)
+		runtime.KeepAlive(buffer)
+	}()
 }
+
 //export CTestCall_preserve_struct_attrs_test
 func CTestCall_preserve_struct_attrs_test(data C.PreserveStructAttrsRequestRef, slot *C.void, cb *C.void) {
-_new_data := newPreserveStructAttrsRequest(data)
-    go func() {
-resp := TestCallImpl.preserve_struct_attrs_test(&_new_data)
-resp_ref, buffer := cvt_ref(cntPreserveStructAttrsResponse, refPreserveStructAttrsResponse)(&resp)
-asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
-runtime.KeepAlive(resp_ref)
-runtime.KeepAlive(resp)
-runtime.KeepAlive(buffer)
-}()
+	_new_data := newPreserveStructAttrsRequest(data)
+	go func() {
+		resp := TestCallImpl.preserve_struct_attrs_test(&_new_data)
+		resp_ref, buffer := cvt_ref(cntPreserveStructAttrsResponse, refPreserveStructAttrsResponse)(&resp)
+		asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+		runtime.KeepAlive(resp_ref)
+		runtime.KeepAlive(resp)
+		runtime.KeepAlive(buffer)
+	}()
 }
 
-        // An alternative impl of unsafe.String for go1.18
-        func unsafeString(ptr *byte, length int) string {
-            sliceHeader := &reflect.SliceHeader{
-                Data: uintptr(unsafe.Pointer(ptr)),
-                Len:  length,
-                Cap:  length,
-            }
-            return *(*string)(unsafe.Pointer(sliceHeader))
-        }
-
-        // An alternative impl of unsafe.StringData for go1.18
-        func unsafeStringData(s string) *byte {
-            return (*byte)(unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&s)).Data))
-        }
-        func newString(s_ref C.StringRef) string {
-            return unsafeString((*byte)(unsafe.Pointer(s_ref.ptr)), int(s_ref.len))
-        }
-        func refString(s *string, _ *[]byte) C.StringRef {
-            return C.StringRef{
-                ptr: (*C.uint8_t)(unsafeStringData(*s)),
-                len: C.uintptr_t(len(*s)),
-            }
-        }
-        
-        func ownString(s_ref C.StringRef) string {
-            return string(unsafe.Slice((*byte)(unsafe.Pointer(s_ref.ptr)), int(s_ref.len)))
-        }
-        func cntString(_ *string, _ *uint) [0]C.StringRef { return [0]C.StringRef{} }
-        func new_list_mapper[T1, T2 any](f func(T1) T2) func(C.ListRef) []T2 {
-            return func(x C.ListRef) []T2 {
-                input := unsafe.Slice((*T1)(unsafe.Pointer(x.ptr)), x.len)
-                output := make([]T2, len(input))
-                for i, v := range input {
-                    output[i] = f(v)
-                }
-                return output
-            }
-        }
-        func new_list_mapper_primitive[T1, T2 any](_ func(T1) T2) func(C.ListRef) []T2 {
-            return func(x C.ListRef) []T2 {
-                return unsafe.Slice((*T2)(unsafe.Pointer(x.ptr)), x.len)
-            }
-        }
-        // only handle non-primitive type T
-        func cnt_list_mapper[T, R any](f func(s *T, cnt *uint)[0]R) func(s *[]T, cnt *uint) [0]C.ListRef {
-            return func(s *[]T, cnt *uint) [0]C.ListRef {
-                for _, v := range *s {
-                    f(&v, cnt)
-                }
-                *cnt += uint(len(*s)) * size_of[R]()
-                return [0]C.ListRef{}
-            }
-        }
-
-        // only handle primitive type T
-        func cnt_list_mapper_primitive[T, R any](_ func(s *T, cnt *uint)[0]R) func(s *[]T, cnt *uint) [0]C.ListRef {
-            return func(s *[]T, cnt *uint) [0]C.ListRef {return [0]C.ListRef{}}
-        }
-        // only handle non-primitive type T
-        func ref_list_mapper[T, R any](f func(s *T, buffer *[]byte) R) func(s *[]T, buffer *[]byte) C.ListRef {
-            return func(s *[]T, buffer *[]byte) C.ListRef {
-                if len(*buffer) == 0 {
-                    return C.ListRef{
-                        ptr: unsafe.Pointer(nil),
-                        len: C.uintptr_t(len(*s)),
-                    }
-                }
-                ret := C.ListRef{
-                    ptr: unsafe.Pointer(&(*buffer)[0]),
-                    len: C.uintptr_t(len(*s)),
-                }
-                children_bytes := int(size_of[R]()) * len(*s)
-                children := (*buffer)[:children_bytes]
-                *buffer = (*buffer)[children_bytes:]
-                for _, v := range *s {
-                    child := f(&v, buffer)
-                    len := unsafe.Sizeof(child)
-                    copy(children, unsafe.Slice((*byte)(unsafe.Pointer(&child)), len))
-                    children = children[len:]
-                }
-                return ret
-            }
-        }
-        // only handle primitive type T
-        func ref_list_mapper_primitive[T, R any](_ func(s *T, buffer *[]byte) R) func(s *[]T, buffer *[]byte) C.ListRef {
-            return func(s *[]T, buffer *[]byte) C.ListRef {
-                if len(*s) == 0 {
-                    return C.ListRef{
-                        ptr: unsafe.Pointer(nil),
-                        len: C.uintptr_t(0),
-                    }
-                }
-                return C.ListRef{
-                    ptr: unsafe.Pointer(&(*s)[0]),
-                    len: C.uintptr_t(len(*s)),
-                }
-            }
-        }
-        func size_of[T any]() uint {
-            var t T
-            return uint(unsafe.Sizeof(t))
-        }
-        func cvt_ref[R, CR any](cnt_f func(s *R, cnt *uint) [0]CR, ref_f func(p *R, buffer *[]byte) CR) func(p *R) (CR, []byte) {
-            return func(p *R) (CR, []byte) {
-                var cnt uint
-                cnt_f(p, &cnt)
-                buffer := make([]byte, cnt)
-                return ref_f(p, &buffer), buffer
-            }
-        }
-        func cvt_ref_cap[R, CR any](cnt_f func(s *R, cnt *uint) [0]CR, ref_f func(p *R, buffer *[]byte) CR, add_cap uint) func(p *R) (CR, []byte) {
-            return func(p *R) (CR, []byte) {
-                var cnt uint
-                cnt_f(p, &cnt)
-                buffer := make([]byte, cnt, cnt + add_cap)
-                return ref_f(p, &buffer), buffer
-            }
-        }
-
-        func newC_uint8_t(n C.uint8_t) uint8    { return uint8(n) }
-        func newC_uint16_t(n C.uint16_t) uint16 { return uint16(n) }
-        func newC_uint32_t(n C.uint32_t) uint32 { return uint32(n) }
-        func newC_uint64_t(n C.uint64_t) uint64 { return uint64(n) }
-        func newC_int8_t(n C.int8_t) int8       { return int8(n) }
-        func newC_int16_t(n C.int16_t) int16    { return int16(n) }
-        func newC_int32_t(n C.int32_t) int32    { return int32(n) }
-        func newC_int64_t(n C.int64_t) int64    { return int64(n) }
-        func newC_bool(n C.bool) bool           { return bool(n) }
-        func newC_uintptr_t(n C.uintptr_t) uint { return uint(n) }
-        func newC_intptr_t(n C.intptr_t) int    { return int(n) }
-        func newC_float(n C.float) float32      { return float32(n) }
-        func newC_double(n C.double) float64    { return float64(n) }
-
-        func cntC_uint8_t(_ *uint8, _ *uint) [0]C.uint8_t    { return [0]C.uint8_t{} }
-        func cntC_uint16_t(_ *uint16, _ *uint) [0]C.uint16_t { return [0]C.uint16_t{} }
-        func cntC_uint32_t(_ *uint32, _ *uint) [0]C.uint32_t { return [0]C.uint32_t{} }
-        func cntC_uint64_t(_ *uint64, _ *uint) [0]C.uint64_t { return [0]C.uint64_t{} }
-        func cntC_int8_t(_ *int8, _ *uint) [0]C.int8_t       { return [0]C.int8_t{} }
-        func cntC_int16_t(_ *int16, _ *uint) [0]C.int16_t    { return [0]C.int16_t{} }
-        func cntC_int32_t(_ *int32, _ *uint) [0]C.int32_t    { return [0]C.int32_t{} }
-        func cntC_int64_t(_ *int64, _ *uint) [0]C.int64_t    { return [0]C.int64_t{} }
-        func cntC_bool(_ *bool, _ *uint) [0]C.bool           { return [0]C.bool{} }
-        func cntC_uintptr_t(_ *uint, _ *uint) [0]C.uintptr_t { return [0]C.uintptr_t{} }
-        func cntC_intptr_t(_ *int, _ *uint) [0]C.intptr_t    { return [0]C.intptr_t{} }
-        func cntC_float(_ *float32, _ *uint) [0]C.float      { return [0]C.float{} }
-        func cntC_double(_ *float64, _ *uint) [0]C.double    { return [0]C.double{} }
-
-        func refC_uint8_t(p *uint8, _ *[]byte) C.uint8_t    { return C.uint8_t(*p) }
-        func refC_uint16_t(p *uint16, _ *[]byte) C.uint16_t { return C.uint16_t(*p) }
-        func refC_uint32_t(p *uint32, _ *[]byte) C.uint32_t { return C.uint32_t(*p) }
-        func refC_uint64_t(p *uint64, _ *[]byte) C.uint64_t { return C.uint64_t(*p) }
-        func refC_int8_t(p *int8, _ *[]byte) C.int8_t       { return C.int8_t(*p) }
-        func refC_int16_t(p *int16, _ *[]byte) C.int16_t    { return C.int16_t(*p) }
-        func refC_int32_t(p *int32, _ *[]byte) C.int32_t    { return C.int32_t(*p) }
-        func refC_int64_t(p *int64, _ *[]byte) C.int64_t    { return C.int64_t(*p) }
-        func refC_bool(p *bool, _ *[]byte) C.bool           { return C.bool(*p) }
-        func refC_uintptr_t(p *uint, _ *[]byte) C.uintptr_t { return C.uintptr_t(*p) }
-        func refC_intptr_t(p *int, _ *[]byte) C.intptr_t    { return C.intptr_t(*p) }
-        func refC_float(p *float32, _ *[]byte) C.float      { return C.float(*p) }
-        func refC_double(p *float64, _ *[]byte) C.double    { return C.double(*p) }
-        type User struct {
-    id uint32
-    name string
-    age uint8
+// An alternative impl of unsafe.String for go1.18
+func unsafeString(ptr *byte, length int) string {
+	sliceHeader := &reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(ptr)),
+		Len:  length,
+		Cap:  length,
+	}
+	return *(*string)(unsafe.Pointer(sliceHeader))
 }
-func newUser(p C.UserRef) User{
-return User{
-id: newC_uint32_t(p.id),
-name: newString(p.name),
-age: newC_uint8_t(p.age),
+
+// An alternative impl of unsafe.StringData for go1.18
+func unsafeStringData(s string) *byte {
+	return (*byte)(unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&s)).Data))
 }
+func newString(s_ref C.StringRef) string {
+	return unsafeString((*byte)(unsafe.Pointer(s_ref.ptr)), int(s_ref.len))
 }
-func ownUser(p C.UserRef) User{
-return User{
-id: newC_uint32_t(p.id),
-name: ownString(p.name),
-age: newC_uint8_t(p.age),
+func refString(s *string, _ *[]byte) C.StringRef {
+	return C.StringRef{
+		ptr: (*C.uint8_t)(unsafeStringData(*s)),
+		len: C.uintptr_t(len(*s)),
+	}
 }
+
+func ownString(s_ref C.StringRef) string {
+	return string(unsafe.Slice((*byte)(unsafe.Pointer(s_ref.ptr)), int(s_ref.len)))
+}
+func cntString(_ *string, _ *uint) [0]C.StringRef { return [0]C.StringRef{} }
+func new_list_mapper[T1, T2 any](f func(T1) T2) func(C.ListRef) []T2 {
+	return func(x C.ListRef) []T2 {
+		input := unsafe.Slice((*T1)(unsafe.Pointer(x.ptr)), x.len)
+		output := make([]T2, len(input))
+		for i, v := range input {
+			output[i] = f(v)
+		}
+		return output
+	}
+}
+func new_list_mapper_primitive[T1, T2 any](_ func(T1) T2) func(C.ListRef) []T2 {
+	return func(x C.ListRef) []T2 {
+		return unsafe.Slice((*T2)(unsafe.Pointer(x.ptr)), x.len)
+	}
+}
+
+// only handle non-primitive type T
+func cnt_list_mapper[T, R any](f func(s *T, cnt *uint) [0]R) func(s *[]T, cnt *uint) [0]C.ListRef {
+	return func(s *[]T, cnt *uint) [0]C.ListRef {
+		for _, v := range *s {
+			f(&v, cnt)
+		}
+		*cnt += uint(len(*s)) * size_of[R]()
+		return [0]C.ListRef{}
+	}
+}
+
+// only handle primitive type T
+func cnt_list_mapper_primitive[T, R any](_ func(s *T, cnt *uint) [0]R) func(s *[]T, cnt *uint) [0]C.ListRef {
+	return func(s *[]T, cnt *uint) [0]C.ListRef { return [0]C.ListRef{} }
+}
+
+// only handle non-primitive type T
+func ref_list_mapper[T, R any](f func(s *T, buffer *[]byte) R) func(s *[]T, buffer *[]byte) C.ListRef {
+	return func(s *[]T, buffer *[]byte) C.ListRef {
+		if len(*buffer) == 0 {
+			return C.ListRef{
+				ptr: unsafe.Pointer(nil),
+				len: C.uintptr_t(len(*s)),
+			}
+		}
+		ret := C.ListRef{
+			ptr: unsafe.Pointer(&(*buffer)[0]),
+			len: C.uintptr_t(len(*s)),
+		}
+		children_bytes := int(size_of[R]()) * len(*s)
+		children := (*buffer)[:children_bytes]
+		*buffer = (*buffer)[children_bytes:]
+		for _, v := range *s {
+			child := f(&v, buffer)
+			len := unsafe.Sizeof(child)
+			copy(children, unsafe.Slice((*byte)(unsafe.Pointer(&child)), len))
+			children = children[len:]
+		}
+		return ret
+	}
+}
+
+// only handle primitive type T
+func ref_list_mapper_primitive[T, R any](_ func(s *T, buffer *[]byte) R) func(s *[]T, buffer *[]byte) C.ListRef {
+	return func(s *[]T, buffer *[]byte) C.ListRef {
+		if len(*s) == 0 {
+			return C.ListRef{
+				ptr: unsafe.Pointer(nil),
+				len: C.uintptr_t(0),
+			}
+		}
+		return C.ListRef{
+			ptr: unsafe.Pointer(&(*s)[0]),
+			len: C.uintptr_t(len(*s)),
+		}
+	}
+}
+func size_of[T any]() uint {
+	var t T
+	return uint(unsafe.Sizeof(t))
+}
+func cvt_ref[R, CR any](cnt_f func(s *R, cnt *uint) [0]CR, ref_f func(p *R, buffer *[]byte) CR) func(p *R) (CR, []byte) {
+	return func(p *R) (CR, []byte) {
+		var cnt uint
+		cnt_f(p, &cnt)
+		buffer := make([]byte, cnt)
+		return ref_f(p, &buffer), buffer
+	}
+}
+func cvt_ref_cap[R, CR any](cnt_f func(s *R, cnt *uint) [0]CR, ref_f func(p *R, buffer *[]byte) CR, add_cap uint) func(p *R) (CR, []byte) {
+	return func(p *R) (CR, []byte) {
+		var cnt uint
+		cnt_f(p, &cnt)
+		buffer := make([]byte, cnt, cnt+add_cap)
+		return ref_f(p, &buffer), buffer
+	}
+}
+
+func newC_uint8_t(n C.uint8_t) uint8    { return uint8(n) }
+func newC_uint16_t(n C.uint16_t) uint16 { return uint16(n) }
+func newC_uint32_t(n C.uint32_t) uint32 { return uint32(n) }
+func newC_uint64_t(n C.uint64_t) uint64 { return uint64(n) }
+func newC_int8_t(n C.int8_t) int8       { return int8(n) }
+func newC_int16_t(n C.int16_t) int16    { return int16(n) }
+func newC_int32_t(n C.int32_t) int32    { return int32(n) }
+func newC_int64_t(n C.int64_t) int64    { return int64(n) }
+func newC_bool(n C.bool) bool           { return bool(n) }
+func newC_uintptr_t(n C.uintptr_t) uint { return uint(n) }
+func newC_intptr_t(n C.intptr_t) int    { return int(n) }
+func newC_float(n C.float) float32      { return float32(n) }
+func newC_double(n C.double) float64    { return float64(n) }
+
+func cntC_uint8_t(_ *uint8, _ *uint) [0]C.uint8_t    { return [0]C.uint8_t{} }
+func cntC_uint16_t(_ *uint16, _ *uint) [0]C.uint16_t { return [0]C.uint16_t{} }
+func cntC_uint32_t(_ *uint32, _ *uint) [0]C.uint32_t { return [0]C.uint32_t{} }
+func cntC_uint64_t(_ *uint64, _ *uint) [0]C.uint64_t { return [0]C.uint64_t{} }
+func cntC_int8_t(_ *int8, _ *uint) [0]C.int8_t       { return [0]C.int8_t{} }
+func cntC_int16_t(_ *int16, _ *uint) [0]C.int16_t    { return [0]C.int16_t{} }
+func cntC_int32_t(_ *int32, _ *uint) [0]C.int32_t    { return [0]C.int32_t{} }
+func cntC_int64_t(_ *int64, _ *uint) [0]C.int64_t    { return [0]C.int64_t{} }
+func cntC_bool(_ *bool, _ *uint) [0]C.bool           { return [0]C.bool{} }
+func cntC_uintptr_t(_ *uint, _ *uint) [0]C.uintptr_t { return [0]C.uintptr_t{} }
+func cntC_intptr_t(_ *int, _ *uint) [0]C.intptr_t    { return [0]C.intptr_t{} }
+func cntC_float(_ *float32, _ *uint) [0]C.float      { return [0]C.float{} }
+func cntC_double(_ *float64, _ *uint) [0]C.double    { return [0]C.double{} }
+
+func refC_uint8_t(p *uint8, _ *[]byte) C.uint8_t    { return C.uint8_t(*p) }
+func refC_uint16_t(p *uint16, _ *[]byte) C.uint16_t { return C.uint16_t(*p) }
+func refC_uint32_t(p *uint32, _ *[]byte) C.uint32_t { return C.uint32_t(*p) }
+func refC_uint64_t(p *uint64, _ *[]byte) C.uint64_t { return C.uint64_t(*p) }
+func refC_int8_t(p *int8, _ *[]byte) C.int8_t       { return C.int8_t(*p) }
+func refC_int16_t(p *int16, _ *[]byte) C.int16_t    { return C.int16_t(*p) }
+func refC_int32_t(p *int32, _ *[]byte) C.int32_t    { return C.int32_t(*p) }
+func refC_int64_t(p *int64, _ *[]byte) C.int64_t    { return C.int64_t(*p) }
+func refC_bool(p *bool, _ *[]byte) C.bool           { return C.bool(*p) }
+func refC_uintptr_t(p *uint, _ *[]byte) C.uintptr_t { return C.uintptr_t(*p) }
+func refC_intptr_t(p *int, _ *[]byte) C.intptr_t    { return C.intptr_t(*p) }
+func refC_float(p *float32, _ *[]byte) C.float      { return C.float(*p) }
+func refC_double(p *float64, _ *[]byte) C.double    { return C.double(*p) }
+
+type User struct {
+	id   uint32
+	name string
+	age  uint8
+}
+
+func newUser(p C.UserRef) User {
+	return User{
+		id:   newC_uint32_t(p.id),
+		name: newString(p.name),
+		age:  newC_uint8_t(p.age),
+	}
+}
+func ownUser(p C.UserRef) User {
+	return User{
+		id:   newC_uint32_t(p.id),
+		name: ownString(p.name),
+		age:  newC_uint8_t(p.age),
+	}
 }
 func cntUser(s *User, cnt *uint) [0]C.UserRef {
-_ = s
-_ = cnt
-return [0]C.UserRef{}
+	_ = s
+	_ = cnt
+	return [0]C.UserRef{}
 }
-func refUser(p *User, buffer *[]byte) C.UserRef{
-return C.UserRef{
-id: refC_uint32_t(&p.id, buffer),
-name: refString(&p.name, buffer),
-age: refC_uint8_t(&p.age, buffer),
+func refUser(p *User, buffer *[]byte) C.UserRef {
+	return C.UserRef{
+		id:   refC_uint32_t(&p.id, buffer),
+		name: refString(&p.name, buffer),
+		age:  refC_uint8_t(&p.age, buffer),
+	}
 }
-}
+
 type LoginRequest struct {
-    user User
-    password string
+	user     User
+	password string
 }
-func newLoginRequest(p C.LoginRequestRef) LoginRequest{
-return LoginRequest{
-user: newUser(p.user),
-password: newString(p.password),
+
+func newLoginRequest(p C.LoginRequestRef) LoginRequest {
+	return LoginRequest{
+		user:     newUser(p.user),
+		password: newString(p.password),
+	}
 }
-}
-func ownLoginRequest(p C.LoginRequestRef) LoginRequest{
-return LoginRequest{
-user: ownUser(p.user),
-password: ownString(p.password),
-}
+func ownLoginRequest(p C.LoginRequestRef) LoginRequest {
+	return LoginRequest{
+		user:     ownUser(p.user),
+		password: ownString(p.password),
+	}
 }
 func cntLoginRequest(s *LoginRequest, cnt *uint) [0]C.LoginRequestRef {
-_ = s
-_ = cnt
-return [0]C.LoginRequestRef{}
+	_ = s
+	_ = cnt
+	return [0]C.LoginRequestRef{}
 }
-func refLoginRequest(p *LoginRequest, buffer *[]byte) C.LoginRequestRef{
-return C.LoginRequestRef{
-user: refUser(&p.user, buffer),
-password: refString(&p.password, buffer),
+func refLoginRequest(p *LoginRequest, buffer *[]byte) C.LoginRequestRef {
+	return C.LoginRequestRef{
+		user:     refUser(&p.user, buffer),
+		password: refString(&p.password, buffer),
+	}
 }
-}
+
 type LoginResponse struct {
-    succ bool
-    message string
-    token []uint8
+	succ    bool
+	message string
+	token   []uint8
 }
-func newLoginResponse(p C.LoginResponseRef) LoginResponse{
-return LoginResponse{
-succ: newC_bool(p.succ),
-message: newString(p.message),
-token: new_list_mapper_primitive(newC_uint8_t)(p.token),
+
+func newLoginResponse(p C.LoginResponseRef) LoginResponse {
+	return LoginResponse{
+		succ:    newC_bool(p.succ),
+		message: newString(p.message),
+		token:   new_list_mapper_primitive(newC_uint8_t)(p.token),
+	}
 }
-}
-func ownLoginResponse(p C.LoginResponseRef) LoginResponse{
-return LoginResponse{
-succ: newC_bool(p.succ),
-message: ownString(p.message),
-token: new_list_mapper(newC_uint8_t)(p.token),
-}
+func ownLoginResponse(p C.LoginResponseRef) LoginResponse {
+	return LoginResponse{
+		succ:    newC_bool(p.succ),
+		message: ownString(p.message),
+		token:   new_list_mapper(newC_uint8_t)(p.token),
+	}
 }
 func cntLoginResponse(s *LoginResponse, cnt *uint) [0]C.LoginResponseRef {
-_ = s
-_ = cnt
-return [0]C.LoginResponseRef{}
+	_ = s
+	_ = cnt
+	return [0]C.LoginResponseRef{}
 }
-func refLoginResponse(p *LoginResponse, buffer *[]byte) C.LoginResponseRef{
-return C.LoginResponseRef{
-succ: refC_bool(&p.succ, buffer),
-message: refString(&p.message, buffer),
-token: ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
+func refLoginResponse(p *LoginResponse, buffer *[]byte) C.LoginResponseRef {
+	return C.LoginResponseRef{
+		succ:    refC_bool(&p.succ, buffer),
+		message: refString(&p.message, buffer),
+		token:   ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
+	}
 }
-}
+
 type LogoutRequest struct {
-    token []uint8
-    user_ids []uint32
+	token    []uint8
+	user_ids []uint32
 }
-func newLogoutRequest(p C.LogoutRequestRef) LogoutRequest{
-return LogoutRequest{
-token: new_list_mapper_primitive(newC_uint8_t)(p.token),
-user_ids: new_list_mapper_primitive(newC_uint32_t)(p.user_ids),
+
+func newLogoutRequest(p C.LogoutRequestRef) LogoutRequest {
+	return LogoutRequest{
+		token:    new_list_mapper_primitive(newC_uint8_t)(p.token),
+		user_ids: new_list_mapper_primitive(newC_uint32_t)(p.user_ids),
+	}
 }
-}
-func ownLogoutRequest(p C.LogoutRequestRef) LogoutRequest{
-return LogoutRequest{
-token: new_list_mapper(newC_uint8_t)(p.token),
-user_ids: new_list_mapper(newC_uint32_t)(p.user_ids),
-}
+func ownLogoutRequest(p C.LogoutRequestRef) LogoutRequest {
+	return LogoutRequest{
+		token:    new_list_mapper(newC_uint8_t)(p.token),
+		user_ids: new_list_mapper(newC_uint32_t)(p.user_ids),
+	}
 }
 func cntLogoutRequest(s *LogoutRequest, cnt *uint) [0]C.LogoutRequestRef {
-_ = s
-_ = cnt
-return [0]C.LogoutRequestRef{}
+	_ = s
+	_ = cnt
+	return [0]C.LogoutRequestRef{}
 }
-func refLogoutRequest(p *LogoutRequest, buffer *[]byte) C.LogoutRequestRef{
-return C.LogoutRequestRef{
-token: ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
-user_ids: ref_list_mapper_primitive(refC_uint32_t)(&p.user_ids, buffer),
+func refLogoutRequest(p *LogoutRequest, buffer *[]byte) C.LogoutRequestRef {
+	return C.LogoutRequestRef{
+		token:    ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
+		user_ids: ref_list_mapper_primitive(refC_uint32_t)(&p.user_ids, buffer),
+	}
 }
-}
+
 type FriendsListRequest struct {
-    token []uint8
-    user_ids []uint32
+	token    []uint8
+	user_ids []uint32
 }
-func newFriendsListRequest(p C.FriendsListRequestRef) FriendsListRequest{
-return FriendsListRequest{
-token: new_list_mapper_primitive(newC_uint8_t)(p.token),
-user_ids: new_list_mapper_primitive(newC_uint32_t)(p.user_ids),
+
+func newFriendsListRequest(p C.FriendsListRequestRef) FriendsListRequest {
+	return FriendsListRequest{
+		token:    new_list_mapper_primitive(newC_uint8_t)(p.token),
+		user_ids: new_list_mapper_primitive(newC_uint32_t)(p.user_ids),
+	}
 }
-}
-func ownFriendsListRequest(p C.FriendsListRequestRef) FriendsListRequest{
-return FriendsListRequest{
-token: new_list_mapper(newC_uint8_t)(p.token),
-user_ids: new_list_mapper(newC_uint32_t)(p.user_ids),
-}
+func ownFriendsListRequest(p C.FriendsListRequestRef) FriendsListRequest {
+	return FriendsListRequest{
+		token:    new_list_mapper(newC_uint8_t)(p.token),
+		user_ids: new_list_mapper(newC_uint32_t)(p.user_ids),
+	}
 }
 func cntFriendsListRequest(s *FriendsListRequest, cnt *uint) [0]C.FriendsListRequestRef {
-_ = s
-_ = cnt
-return [0]C.FriendsListRequestRef{}
+	_ = s
+	_ = cnt
+	return [0]C.FriendsListRequestRef{}
 }
-func refFriendsListRequest(p *FriendsListRequest, buffer *[]byte) C.FriendsListRequestRef{
-return C.FriendsListRequestRef{
-token: ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
-user_ids: ref_list_mapper_primitive(refC_uint32_t)(&p.user_ids, buffer),
+func refFriendsListRequest(p *FriendsListRequest, buffer *[]byte) C.FriendsListRequestRef {
+	return C.FriendsListRequestRef{
+		token:    ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
+		user_ids: ref_list_mapper_primitive(refC_uint32_t)(&p.user_ids, buffer),
+	}
 }
-}
+
 type FriendsListResponse struct {
-    users []User
+	users []User
 }
-func newFriendsListResponse(p C.FriendsListResponseRef) FriendsListResponse{
-return FriendsListResponse{
-users: new_list_mapper(newUser)(p.users),
+
+func newFriendsListResponse(p C.FriendsListResponseRef) FriendsListResponse {
+	return FriendsListResponse{
+		users: new_list_mapper(newUser)(p.users),
+	}
 }
-}
-func ownFriendsListResponse(p C.FriendsListResponseRef) FriendsListResponse{
-return FriendsListResponse{
-users: new_list_mapper(ownUser)(p.users),
-}
+func ownFriendsListResponse(p C.FriendsListResponseRef) FriendsListResponse {
+	return FriendsListResponse{
+		users: new_list_mapper(ownUser)(p.users),
+	}
 }
 func cntFriendsListResponse(s *FriendsListResponse, cnt *uint) [0]C.FriendsListResponseRef {
-cnt_list_mapper(cntUser)(&s.users, cnt)
-return [0]C.FriendsListResponseRef{}
+	cnt_list_mapper(cntUser)(&s.users, cnt)
+	return [0]C.FriendsListResponseRef{}
 }
-func refFriendsListResponse(p *FriendsListResponse, buffer *[]byte) C.FriendsListResponseRef{
-return C.FriendsListResponseRef{
-users: ref_list_mapper(refUser)(&p.users, buffer),
+func refFriendsListResponse(p *FriendsListResponse, buffer *[]byte) C.FriendsListResponseRef {
+	return C.FriendsListResponseRef{
+		users: ref_list_mapper(refUser)(&p.users, buffer),
+	}
 }
-}
+
 type PMFriendRequest struct {
-    user_id uint32
-    token []uint8
-    message string
+	user_id uint32
+	token   []uint8
+	message string
 }
-func newPMFriendRequest(p C.PMFriendRequestRef) PMFriendRequest{
-return PMFriendRequest{
-user_id: newC_uint32_t(p.user_id),
-token: new_list_mapper_primitive(newC_uint8_t)(p.token),
-message: newString(p.message),
+
+func newPMFriendRequest(p C.PMFriendRequestRef) PMFriendRequest {
+	return PMFriendRequest{
+		user_id: newC_uint32_t(p.user_id),
+		token:   new_list_mapper_primitive(newC_uint8_t)(p.token),
+		message: newString(p.message),
+	}
 }
-}
-func ownPMFriendRequest(p C.PMFriendRequestRef) PMFriendRequest{
-return PMFriendRequest{
-user_id: newC_uint32_t(p.user_id),
-token: new_list_mapper(newC_uint8_t)(p.token),
-message: ownString(p.message),
-}
+func ownPMFriendRequest(p C.PMFriendRequestRef) PMFriendRequest {
+	return PMFriendRequest{
+		user_id: newC_uint32_t(p.user_id),
+		token:   new_list_mapper(newC_uint8_t)(p.token),
+		message: ownString(p.message),
+	}
 }
 func cntPMFriendRequest(s *PMFriendRequest, cnt *uint) [0]C.PMFriendRequestRef {
-_ = s
-_ = cnt
-return [0]C.PMFriendRequestRef{}
+	_ = s
+	_ = cnt
+	return [0]C.PMFriendRequestRef{}
 }
-func refPMFriendRequest(p *PMFriendRequest, buffer *[]byte) C.PMFriendRequestRef{
-return C.PMFriendRequestRef{
-user_id: refC_uint32_t(&p.user_id, buffer),
-token: ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
-message: refString(&p.message, buffer),
+func refPMFriendRequest(p *PMFriendRequest, buffer *[]byte) C.PMFriendRequestRef {
+	return C.PMFriendRequestRef{
+		user_id: refC_uint32_t(&p.user_id, buffer),
+		token:   ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
+		message: refString(&p.message, buffer),
+	}
 }
-}
+
 type PMFriendResponse struct {
-    succ bool
-    message string
+	succ    bool
+	message string
 }
-func newPMFriendResponse(p C.PMFriendResponseRef) PMFriendResponse{
-return PMFriendResponse{
-succ: newC_bool(p.succ),
-message: newString(p.message),
+
+func newPMFriendResponse(p C.PMFriendResponseRef) PMFriendResponse {
+	return PMFriendResponse{
+		succ:    newC_bool(p.succ),
+		message: newString(p.message),
+	}
 }
-}
-func ownPMFriendResponse(p C.PMFriendResponseRef) PMFriendResponse{
-return PMFriendResponse{
-succ: newC_bool(p.succ),
-message: ownString(p.message),
-}
+func ownPMFriendResponse(p C.PMFriendResponseRef) PMFriendResponse {
+	return PMFriendResponse{
+		succ:    newC_bool(p.succ),
+		message: ownString(p.message),
+	}
 }
 func cntPMFriendResponse(s *PMFriendResponse, cnt *uint) [0]C.PMFriendResponseRef {
-_ = s
-_ = cnt
-return [0]C.PMFriendResponseRef{}
+	_ = s
+	_ = cnt
+	return [0]C.PMFriendResponseRef{}
 }
-func refPMFriendResponse(p *PMFriendResponse, buffer *[]byte) C.PMFriendResponseRef{
-return C.PMFriendResponseRef{
-succ: refC_bool(&p.succ, buffer),
-message: refString(&p.message, buffer),
+func refPMFriendResponse(p *PMFriendResponse, buffer *[]byte) C.PMFriendResponseRef {
+	return C.PMFriendResponseRef{
+		succ:    refC_bool(&p.succ, buffer),
+		message: refString(&p.message, buffer),
+	}
 }
-}
+
 type PreserveStructAttrsRequest struct {
-    UserId uint64
-    UserName string
+	UserId   uint64
+	UserName string
 }
-func newPreserveStructAttrsRequest(p C.PreserveStructAttrsRequestRef) PreserveStructAttrsRequest{
-return PreserveStructAttrsRequest{
-UserId: newC_uint64_t(p.UserId),
-UserName: newString(p.UserName),
+
+func newPreserveStructAttrsRequest(p C.PreserveStructAttrsRequestRef) PreserveStructAttrsRequest {
+	return PreserveStructAttrsRequest{
+		UserId:   newC_uint64_t(p.UserId),
+		UserName: newString(p.UserName),
+	}
 }
-}
-func ownPreserveStructAttrsRequest(p C.PreserveStructAttrsRequestRef) PreserveStructAttrsRequest{
-return PreserveStructAttrsRequest{
-UserId: newC_uint64_t(p.UserId),
-UserName: ownString(p.UserName),
-}
+func ownPreserveStructAttrsRequest(p C.PreserveStructAttrsRequestRef) PreserveStructAttrsRequest {
+	return PreserveStructAttrsRequest{
+		UserId:   newC_uint64_t(p.UserId),
+		UserName: ownString(p.UserName),
+	}
 }
 func cntPreserveStructAttrsRequest(s *PreserveStructAttrsRequest, cnt *uint) [0]C.PreserveStructAttrsRequestRef {
-_ = s
-_ = cnt
-return [0]C.PreserveStructAttrsRequestRef{}
+	_ = s
+	_ = cnt
+	return [0]C.PreserveStructAttrsRequestRef{}
 }
-func refPreserveStructAttrsRequest(p *PreserveStructAttrsRequest, buffer *[]byte) C.PreserveStructAttrsRequestRef{
-return C.PreserveStructAttrsRequestRef{
-UserId: refC_uint64_t(&p.UserId, buffer),
-UserName: refString(&p.UserName, buffer),
+func refPreserveStructAttrsRequest(p *PreserveStructAttrsRequest, buffer *[]byte) C.PreserveStructAttrsRequestRef {
+	return C.PreserveStructAttrsRequestRef{
+		UserId:   refC_uint64_t(&p.UserId, buffer),
+		UserName: refString(&p.UserName, buffer),
+	}
 }
-}
+
 type PreserveStructAttrsResponse struct {
-    Success bool
+	Success bool
 }
-func newPreserveStructAttrsResponse(p C.PreserveStructAttrsResponseRef) PreserveStructAttrsResponse{
-return PreserveStructAttrsResponse{
-Success: newC_bool(p.Success),
+
+func newPreserveStructAttrsResponse(p C.PreserveStructAttrsResponseRef) PreserveStructAttrsResponse {
+	return PreserveStructAttrsResponse{
+		Success: newC_bool(p.Success),
+	}
 }
-}
-func ownPreserveStructAttrsResponse(p C.PreserveStructAttrsResponseRef) PreserveStructAttrsResponse{
-return PreserveStructAttrsResponse{
-Success: newC_bool(p.Success),
-}
+func ownPreserveStructAttrsResponse(p C.PreserveStructAttrsResponseRef) PreserveStructAttrsResponse {
+	return PreserveStructAttrsResponse{
+		Success: newC_bool(p.Success),
+	}
 }
 func cntPreserveStructAttrsResponse(s *PreserveStructAttrsResponse, cnt *uint) [0]C.PreserveStructAttrsResponseRef {
-_ = s
-_ = cnt
-return [0]C.PreserveStructAttrsResponseRef{}
+	_ = s
+	_ = cnt
+	return [0]C.PreserveStructAttrsResponseRef{}
 }
-func refPreserveStructAttrsResponse(p *PreserveStructAttrsResponse, buffer *[]byte) C.PreserveStructAttrsResponseRef{
-return C.PreserveStructAttrsResponseRef{
-Success: refC_bool(&p.Success, buffer),
-}
+func refPreserveStructAttrsResponse(p *PreserveStructAttrsResponse, buffer *[]byte) C.PreserveStructAttrsResponseRef {
+	return C.PreserveStructAttrsResponseRef{
+		Success: refC_bool(&p.Success, buffer),
+	}
 }
 func main() {}

--- a/test/go/gen.go
+++ b/test/go/gen.go
@@ -59,510 +59,554 @@ typedef struct PMFriendResponseRef {
   bool succ;
   struct StringRef message;
 } PMFriendResponseRef;
+
+typedef struct PreserveStructAttrsRequestRef {
+  uint64_t UserId;
+  struct StringRef UserName;
+} PreserveStructAttrsRequestRef;
+
+typedef struct PreserveStructAttrsResponseRef {
+  bool Success;
+} PreserveStructAttrsResponseRef;
 */
 import "C"
 import (
-	"reflect"
-	"runtime"
-	"unsafe"
+"unsafe"
+"runtime"
+"reflect"
 
-	"github.com/ihciah/rust2go/asmcall"
+"github.com/ihciah/rust2go/asmcall"
 )
-
 var TestCallImpl TestCall
-
 type TestCall interface {
-	ping(n uint) uint
-	login(req *LoginRequest) LoginResponse
-	logout(req *User)
-	add_friends(req *FriendsListRequest) FriendsListResponse
-	delete_friends(req *FriendsListRequest) FriendsListResponse
-	pm_friend(req *PMFriendRequest) PMFriendResponse
-	multi_param_test(user *User, message *string, token *[]uint8) LoginResponse
+ping(n uint) uint
+login(req *LoginRequest) LoginResponse
+logout(req *User) 
+add_friends(req *FriendsListRequest) FriendsListResponse
+delete_friends(req *FriendsListRequest) FriendsListResponse
+pm_friend(req *PMFriendRequest) PMFriendResponse
+multi_param_test(user *User, message *string, token *[]uint8) LoginResponse
+preserve_struct_attrs_test(data *PreserveStructAttrsRequest) PreserveStructAttrsResponse
 }
-
 //export CTestCall_ping
 func CTestCall_ping(n C.uintptr_t, slot *C.void, cb *C.void) {
-	_new_n := newC_uintptr_t(n)
-	resp := TestCallImpl.ping(_new_n)
-	resp_ref, buffer := cvt_ref(cntC_uintptr_t, refC_uintptr_t)(&resp)
-	asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
-	runtime.KeepAlive(resp_ref)
-	runtime.KeepAlive(resp)
-	runtime.KeepAlive(buffer)
+_new_n := newC_uintptr_t(n)
+resp := TestCallImpl.ping(_new_n)
+resp_ref, buffer := cvt_ref(cntC_uintptr_t, refC_uintptr_t)(&resp)
+asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+runtime.KeepAlive(resp_ref)
+runtime.KeepAlive(resp)
+runtime.KeepAlive(buffer)
 }
-
 //export CTestCall_login
 func CTestCall_login(req C.LoginRequestRef, slot *C.void, cb *C.void) {
-	_new_req := newLoginRequest(req)
-	resp := TestCallImpl.login(&_new_req)
-	resp_ref, buffer := cvt_ref(cntLoginResponse, refLoginResponse)(&resp)
-	asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
-	runtime.KeepAlive(resp_ref)
-	runtime.KeepAlive(resp)
-	runtime.KeepAlive(buffer)
+_new_req := newLoginRequest(req)
+resp := TestCallImpl.login(&_new_req)
+resp_ref, buffer := cvt_ref(cntLoginResponse, refLoginResponse)(&resp)
+asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+runtime.KeepAlive(resp_ref)
+runtime.KeepAlive(resp)
+runtime.KeepAlive(buffer)
 }
-
 //export CTestCall_logout
-func CTestCall_logout(req C.UserRef) {
-	_new_req := newUser(req)
-	TestCallImpl.logout(&_new_req)
+func CTestCall_logout(req C.UserRef, ) {
+_new_req := newUser(req)
+    TestCallImpl.logout(&_new_req)
 }
-
 //export CTestCall_add_friends
 func CTestCall_add_friends(req C.FriendsListRequestRef, slot *C.void, cb *C.void) {
-	_new_req := newFriendsListRequest(req)
-	go func() {
-		resp := TestCallImpl.add_friends(&_new_req)
-		resp_ref, buffer := cvt_ref(cntFriendsListResponse, refFriendsListResponse)(&resp)
-		asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
-		runtime.KeepAlive(resp_ref)
-		runtime.KeepAlive(resp)
-		runtime.KeepAlive(buffer)
-	}()
+_new_req := newFriendsListRequest(req)
+    go func() {
+resp := TestCallImpl.add_friends(&_new_req)
+resp_ref, buffer := cvt_ref(cntFriendsListResponse, refFriendsListResponse)(&resp)
+asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+runtime.KeepAlive(resp_ref)
+runtime.KeepAlive(resp)
+runtime.KeepAlive(buffer)
+}()
 }
-
 //export CTestCall_delete_friends
 func CTestCall_delete_friends(req C.FriendsListRequestRef, slot *C.void, cb *C.void) {
-	_new_req := newFriendsListRequest(req)
-	go func() {
-		resp := TestCallImpl.delete_friends(&_new_req)
-		resp_ref, buffer := cvt_ref(cntFriendsListResponse, refFriendsListResponse)(&resp)
-		asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
-		runtime.KeepAlive(resp_ref)
-		runtime.KeepAlive(resp)
-		runtime.KeepAlive(buffer)
-	}()
+_new_req := newFriendsListRequest(req)
+    go func() {
+resp := TestCallImpl.delete_friends(&_new_req)
+resp_ref, buffer := cvt_ref(cntFriendsListResponse, refFriendsListResponse)(&resp)
+asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+runtime.KeepAlive(resp_ref)
+runtime.KeepAlive(resp)
+runtime.KeepAlive(buffer)
+}()
 }
-
 //export CTestCall_pm_friend
 func CTestCall_pm_friend(req C.PMFriendRequestRef, slot *C.void, cb *C.void) {
-	_new_req := newPMFriendRequest(req)
-	go func() {
-		resp := TestCallImpl.pm_friend(&_new_req)
-		resp_ref, buffer := cvt_ref(cntPMFriendResponse, refPMFriendResponse)(&resp)
-		asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
-		runtime.KeepAlive(resp_ref)
-		runtime.KeepAlive(resp)
-		runtime.KeepAlive(buffer)
-	}()
+_new_req := newPMFriendRequest(req)
+    go func() {
+resp := TestCallImpl.pm_friend(&_new_req)
+resp_ref, buffer := cvt_ref(cntPMFriendResponse, refPMFriendResponse)(&resp)
+asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+runtime.KeepAlive(resp_ref)
+runtime.KeepAlive(resp)
+runtime.KeepAlive(buffer)
+}()
 }
-
 //export CTestCall_multi_param_test
 func CTestCall_multi_param_test(user C.UserRef, message C.StringRef, token C.ListRef, slot *C.void, cb *C.void) {
-	_new_user := newUser(user)
-	_new_message := newString(message)
-	_new_token := new_list_mapper_primitive(newC_uint8_t)(token)
-	go func() {
-		resp := TestCallImpl.multi_param_test(&_new_user, &_new_message, &_new_token)
-		resp_ref, buffer := cvt_ref(cntLoginResponse, refLoginResponse)(&resp)
-		asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
-		runtime.KeepAlive(resp_ref)
-		runtime.KeepAlive(resp)
-		runtime.KeepAlive(buffer)
-	}()
+_new_user := newUser(user)
+_new_message := newString(message)
+_new_token := new_list_mapper_primitive(newC_uint8_t)(token)
+    go func() {
+resp := TestCallImpl.multi_param_test(&_new_user, &_new_message, &_new_token)
+resp_ref, buffer := cvt_ref(cntLoginResponse, refLoginResponse)(&resp)
+asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+runtime.KeepAlive(resp_ref)
+runtime.KeepAlive(resp)
+runtime.KeepAlive(buffer)
+}()
+}
+//export CTestCall_preserve_struct_attrs_test
+func CTestCall_preserve_struct_attrs_test(data C.PreserveStructAttrsRequestRef, slot *C.void, cb *C.void) {
+_new_data := newPreserveStructAttrsRequest(data)
+    go func() {
+resp := TestCallImpl.preserve_struct_attrs_test(&_new_data)
+resp_ref, buffer := cvt_ref(cntPreserveStructAttrsResponse, refPreserveStructAttrsResponse)(&resp)
+asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+runtime.KeepAlive(resp_ref)
+runtime.KeepAlive(resp)
+runtime.KeepAlive(buffer)
+}()
 }
 
-// An alternative impl of unsafe.String for go1.18
-func unsafeString(ptr *byte, length int) string {
-	sliceHeader := &reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(ptr)),
-		Len:  length,
-		Cap:  length,
-	}
-	return *(*string)(unsafe.Pointer(sliceHeader))
-}
+        // An alternative impl of unsafe.String for go1.18
+        func unsafeString(ptr *byte, length int) string {
+            sliceHeader := &reflect.SliceHeader{
+                Data: uintptr(unsafe.Pointer(ptr)),
+                Len:  length,
+                Cap:  length,
+            }
+            return *(*string)(unsafe.Pointer(sliceHeader))
+        }
 
-// An alternative impl of unsafe.StringData for go1.18
-func unsafeStringData(s string) *byte {
-	return (*byte)(unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&s)).Data))
-}
-func newString(s_ref C.StringRef) string {
-	return unsafeString((*byte)(unsafe.Pointer(s_ref.ptr)), int(s_ref.len))
-}
-func refString(s *string, _ *[]byte) C.StringRef {
-	return C.StringRef{
-		ptr: (*C.uint8_t)(unsafeStringData(*s)),
-		len: C.uintptr_t(len(*s)),
-	}
-}
+        // An alternative impl of unsafe.StringData for go1.18
+        func unsafeStringData(s string) *byte {
+            return (*byte)(unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&s)).Data))
+        }
+        func newString(s_ref C.StringRef) string {
+            return unsafeString((*byte)(unsafe.Pointer(s_ref.ptr)), int(s_ref.len))
+        }
+        func refString(s *string, _ *[]byte) C.StringRef {
+            return C.StringRef{
+                ptr: (*C.uint8_t)(unsafeStringData(*s)),
+                len: C.uintptr_t(len(*s)),
+            }
+        }
+        
+        func ownString(s_ref C.StringRef) string {
+            return string(unsafe.Slice((*byte)(unsafe.Pointer(s_ref.ptr)), int(s_ref.len)))
+        }
+        func cntString(_ *string, _ *uint) [0]C.StringRef { return [0]C.StringRef{} }
+        func new_list_mapper[T1, T2 any](f func(T1) T2) func(C.ListRef) []T2 {
+            return func(x C.ListRef) []T2 {
+                input := unsafe.Slice((*T1)(unsafe.Pointer(x.ptr)), x.len)
+                output := make([]T2, len(input))
+                for i, v := range input {
+                    output[i] = f(v)
+                }
+                return output
+            }
+        }
+        func new_list_mapper_primitive[T1, T2 any](_ func(T1) T2) func(C.ListRef) []T2 {
+            return func(x C.ListRef) []T2 {
+                return unsafe.Slice((*T2)(unsafe.Pointer(x.ptr)), x.len)
+            }
+        }
+        // only handle non-primitive type T
+        func cnt_list_mapper[T, R any](f func(s *T, cnt *uint)[0]R) func(s *[]T, cnt *uint) [0]C.ListRef {
+            return func(s *[]T, cnt *uint) [0]C.ListRef {
+                for _, v := range *s {
+                    f(&v, cnt)
+                }
+                *cnt += uint(len(*s)) * size_of[R]()
+                return [0]C.ListRef{}
+            }
+        }
 
-func ownString(s_ref C.StringRef) string {
-	return string(unsafe.Slice((*byte)(unsafe.Pointer(s_ref.ptr)), int(s_ref.len)))
-}
-func cntString(_ *string, _ *uint) [0]C.StringRef { return [0]C.StringRef{} }
-func new_list_mapper[T1, T2 any](f func(T1) T2) func(C.ListRef) []T2 {
-	return func(x C.ListRef) []T2 {
-		input := unsafe.Slice((*T1)(unsafe.Pointer(x.ptr)), x.len)
-		output := make([]T2, len(input))
-		for i, v := range input {
-			output[i] = f(v)
-		}
-		return output
-	}
-}
-func new_list_mapper_primitive[T1, T2 any](_ func(T1) T2) func(C.ListRef) []T2 {
-	return func(x C.ListRef) []T2 {
-		return unsafe.Slice((*T2)(unsafe.Pointer(x.ptr)), x.len)
-	}
-}
+        // only handle primitive type T
+        func cnt_list_mapper_primitive[T, R any](_ func(s *T, cnt *uint)[0]R) func(s *[]T, cnt *uint) [0]C.ListRef {
+            return func(s *[]T, cnt *uint) [0]C.ListRef {return [0]C.ListRef{}}
+        }
+        // only handle non-primitive type T
+        func ref_list_mapper[T, R any](f func(s *T, buffer *[]byte) R) func(s *[]T, buffer *[]byte) C.ListRef {
+            return func(s *[]T, buffer *[]byte) C.ListRef {
+                if len(*buffer) == 0 {
+                    return C.ListRef{
+                        ptr: unsafe.Pointer(nil),
+                        len: C.uintptr_t(len(*s)),
+                    }
+                }
+                ret := C.ListRef{
+                    ptr: unsafe.Pointer(&(*buffer)[0]),
+                    len: C.uintptr_t(len(*s)),
+                }
+                children_bytes := int(size_of[R]()) * len(*s)
+                children := (*buffer)[:children_bytes]
+                *buffer = (*buffer)[children_bytes:]
+                for _, v := range *s {
+                    child := f(&v, buffer)
+                    len := unsafe.Sizeof(child)
+                    copy(children, unsafe.Slice((*byte)(unsafe.Pointer(&child)), len))
+                    children = children[len:]
+                }
+                return ret
+            }
+        }
+        // only handle primitive type T
+        func ref_list_mapper_primitive[T, R any](_ func(s *T, buffer *[]byte) R) func(s *[]T, buffer *[]byte) C.ListRef {
+            return func(s *[]T, buffer *[]byte) C.ListRef {
+                if len(*s) == 0 {
+                    return C.ListRef{
+                        ptr: unsafe.Pointer(nil),
+                        len: C.uintptr_t(0),
+                    }
+                }
+                return C.ListRef{
+                    ptr: unsafe.Pointer(&(*s)[0]),
+                    len: C.uintptr_t(len(*s)),
+                }
+            }
+        }
+        func size_of[T any]() uint {
+            var t T
+            return uint(unsafe.Sizeof(t))
+        }
+        func cvt_ref[R, CR any](cnt_f func(s *R, cnt *uint) [0]CR, ref_f func(p *R, buffer *[]byte) CR) func(p *R) (CR, []byte) {
+            return func(p *R) (CR, []byte) {
+                var cnt uint
+                cnt_f(p, &cnt)
+                buffer := make([]byte, cnt)
+                return ref_f(p, &buffer), buffer
+            }
+        }
+        func cvt_ref_cap[R, CR any](cnt_f func(s *R, cnt *uint) [0]CR, ref_f func(p *R, buffer *[]byte) CR, add_cap uint) func(p *R) (CR, []byte) {
+            return func(p *R) (CR, []byte) {
+                var cnt uint
+                cnt_f(p, &cnt)
+                buffer := make([]byte, cnt, cnt + add_cap)
+                return ref_f(p, &buffer), buffer
+            }
+        }
 
-// only handle non-primitive type T
-func cnt_list_mapper[T, R any](f func(s *T, cnt *uint) [0]R) func(s *[]T, cnt *uint) [0]C.ListRef {
-	return func(s *[]T, cnt *uint) [0]C.ListRef {
-		for _, v := range *s {
-			f(&v, cnt)
-		}
-		*cnt += uint(len(*s)) * size_of[R]()
-		return [0]C.ListRef{}
-	}
-}
+        func newC_uint8_t(n C.uint8_t) uint8    { return uint8(n) }
+        func newC_uint16_t(n C.uint16_t) uint16 { return uint16(n) }
+        func newC_uint32_t(n C.uint32_t) uint32 { return uint32(n) }
+        func newC_uint64_t(n C.uint64_t) uint64 { return uint64(n) }
+        func newC_int8_t(n C.int8_t) int8       { return int8(n) }
+        func newC_int16_t(n C.int16_t) int16    { return int16(n) }
+        func newC_int32_t(n C.int32_t) int32    { return int32(n) }
+        func newC_int64_t(n C.int64_t) int64    { return int64(n) }
+        func newC_bool(n C.bool) bool           { return bool(n) }
+        func newC_uintptr_t(n C.uintptr_t) uint { return uint(n) }
+        func newC_intptr_t(n C.intptr_t) int    { return int(n) }
+        func newC_float(n C.float) float32      { return float32(n) }
+        func newC_double(n C.double) float64    { return float64(n) }
 
-// only handle primitive type T
-func cnt_list_mapper_primitive[T, R any](_ func(s *T, cnt *uint) [0]R) func(s *[]T, cnt *uint) [0]C.ListRef {
-	return func(s *[]T, cnt *uint) [0]C.ListRef { return [0]C.ListRef{} }
-}
+        func cntC_uint8_t(_ *uint8, _ *uint) [0]C.uint8_t    { return [0]C.uint8_t{} }
+        func cntC_uint16_t(_ *uint16, _ *uint) [0]C.uint16_t { return [0]C.uint16_t{} }
+        func cntC_uint32_t(_ *uint32, _ *uint) [0]C.uint32_t { return [0]C.uint32_t{} }
+        func cntC_uint64_t(_ *uint64, _ *uint) [0]C.uint64_t { return [0]C.uint64_t{} }
+        func cntC_int8_t(_ *int8, _ *uint) [0]C.int8_t       { return [0]C.int8_t{} }
+        func cntC_int16_t(_ *int16, _ *uint) [0]C.int16_t    { return [0]C.int16_t{} }
+        func cntC_int32_t(_ *int32, _ *uint) [0]C.int32_t    { return [0]C.int32_t{} }
+        func cntC_int64_t(_ *int64, _ *uint) [0]C.int64_t    { return [0]C.int64_t{} }
+        func cntC_bool(_ *bool, _ *uint) [0]C.bool           { return [0]C.bool{} }
+        func cntC_uintptr_t(_ *uint, _ *uint) [0]C.uintptr_t { return [0]C.uintptr_t{} }
+        func cntC_intptr_t(_ *int, _ *uint) [0]C.intptr_t    { return [0]C.intptr_t{} }
+        func cntC_float(_ *float32, _ *uint) [0]C.float      { return [0]C.float{} }
+        func cntC_double(_ *float64, _ *uint) [0]C.double    { return [0]C.double{} }
 
-// only handle non-primitive type T
-func ref_list_mapper[T, R any](f func(s *T, buffer *[]byte) R) func(s *[]T, buffer *[]byte) C.ListRef {
-	return func(s *[]T, buffer *[]byte) C.ListRef {
-		if len(*buffer) == 0 {
-			return C.ListRef{
-				ptr: unsafe.Pointer(nil),
-				len: C.uintptr_t(len(*s)),
-			}
-		}
-		ret := C.ListRef{
-			ptr: unsafe.Pointer(&(*buffer)[0]),
-			len: C.uintptr_t(len(*s)),
-		}
-		children_bytes := int(size_of[R]()) * len(*s)
-		children := (*buffer)[:children_bytes]
-		*buffer = (*buffer)[children_bytes:]
-		for _, v := range *s {
-			child := f(&v, buffer)
-			len := unsafe.Sizeof(child)
-			copy(children, unsafe.Slice((*byte)(unsafe.Pointer(&child)), len))
-			children = children[len:]
-		}
-		return ret
-	}
+        func refC_uint8_t(p *uint8, _ *[]byte) C.uint8_t    { return C.uint8_t(*p) }
+        func refC_uint16_t(p *uint16, _ *[]byte) C.uint16_t { return C.uint16_t(*p) }
+        func refC_uint32_t(p *uint32, _ *[]byte) C.uint32_t { return C.uint32_t(*p) }
+        func refC_uint64_t(p *uint64, _ *[]byte) C.uint64_t { return C.uint64_t(*p) }
+        func refC_int8_t(p *int8, _ *[]byte) C.int8_t       { return C.int8_t(*p) }
+        func refC_int16_t(p *int16, _ *[]byte) C.int16_t    { return C.int16_t(*p) }
+        func refC_int32_t(p *int32, _ *[]byte) C.int32_t    { return C.int32_t(*p) }
+        func refC_int64_t(p *int64, _ *[]byte) C.int64_t    { return C.int64_t(*p) }
+        func refC_bool(p *bool, _ *[]byte) C.bool           { return C.bool(*p) }
+        func refC_uintptr_t(p *uint, _ *[]byte) C.uintptr_t { return C.uintptr_t(*p) }
+        func refC_intptr_t(p *int, _ *[]byte) C.intptr_t    { return C.intptr_t(*p) }
+        func refC_float(p *float32, _ *[]byte) C.float      { return C.float(*p) }
+        func refC_double(p *float64, _ *[]byte) C.double    { return C.double(*p) }
+        type User struct {
+    id uint32
+    name string
+    age uint8
 }
-
-// only handle primitive type T
-func ref_list_mapper_primitive[T, R any](_ func(s *T, buffer *[]byte) R) func(s *[]T, buffer *[]byte) C.ListRef {
-	return func(s *[]T, buffer *[]byte) C.ListRef {
-		if len(*s) == 0 {
-			return C.ListRef{
-				ptr: unsafe.Pointer(nil),
-				len: C.uintptr_t(0),
-			}
-		}
-		return C.ListRef{
-			ptr: unsafe.Pointer(&(*s)[0]),
-			len: C.uintptr_t(len(*s)),
-		}
-	}
+func newUser(p C.UserRef) User{
+return User{
+id: newC_uint32_t(p.id),
+name: newString(p.name),
+age: newC_uint8_t(p.age),
 }
-func size_of[T any]() uint {
-	var t T
-	return uint(unsafe.Sizeof(t))
 }
-func cvt_ref[R, CR any](cnt_f func(s *R, cnt *uint) [0]CR, ref_f func(p *R, buffer *[]byte) CR) func(p *R) (CR, []byte) {
-	return func(p *R) (CR, []byte) {
-		var cnt uint
-		cnt_f(p, &cnt)
-		buffer := make([]byte, cnt)
-		return ref_f(p, &buffer), buffer
-	}
+func ownUser(p C.UserRef) User{
+return User{
+id: newC_uint32_t(p.id),
+name: ownString(p.name),
+age: newC_uint8_t(p.age),
 }
-func cvt_ref_cap[R, CR any](cnt_f func(s *R, cnt *uint) [0]CR, ref_f func(p *R, buffer *[]byte) CR, add_cap uint) func(p *R) (CR, []byte) {
-	return func(p *R) (CR, []byte) {
-		var cnt uint
-		cnt_f(p, &cnt)
-		buffer := make([]byte, cnt, cnt+add_cap)
-		return ref_f(p, &buffer), buffer
-	}
-}
-
-func newC_uint8_t(n C.uint8_t) uint8    { return uint8(n) }
-func newC_uint16_t(n C.uint16_t) uint16 { return uint16(n) }
-func newC_uint32_t(n C.uint32_t) uint32 { return uint32(n) }
-func newC_uint64_t(n C.uint64_t) uint64 { return uint64(n) }
-func newC_int8_t(n C.int8_t) int8       { return int8(n) }
-func newC_int16_t(n C.int16_t) int16    { return int16(n) }
-func newC_int32_t(n C.int32_t) int32    { return int32(n) }
-func newC_int64_t(n C.int64_t) int64    { return int64(n) }
-func newC_bool(n C.bool) bool           { return bool(n) }
-func newC_uintptr_t(n C.uintptr_t) uint { return uint(n) }
-func newC_intptr_t(n C.intptr_t) int    { return int(n) }
-func newC_float(n C.float) float32      { return float32(n) }
-func newC_double(n C.double) float64    { return float64(n) }
-
-func cntC_uint8_t(_ *uint8, _ *uint) [0]C.uint8_t    { return [0]C.uint8_t{} }
-func cntC_uint16_t(_ *uint16, _ *uint) [0]C.uint16_t { return [0]C.uint16_t{} }
-func cntC_uint32_t(_ *uint32, _ *uint) [0]C.uint32_t { return [0]C.uint32_t{} }
-func cntC_uint64_t(_ *uint64, _ *uint) [0]C.uint64_t { return [0]C.uint64_t{} }
-func cntC_int8_t(_ *int8, _ *uint) [0]C.int8_t       { return [0]C.int8_t{} }
-func cntC_int16_t(_ *int16, _ *uint) [0]C.int16_t    { return [0]C.int16_t{} }
-func cntC_int32_t(_ *int32, _ *uint) [0]C.int32_t    { return [0]C.int32_t{} }
-func cntC_int64_t(_ *int64, _ *uint) [0]C.int64_t    { return [0]C.int64_t{} }
-func cntC_bool(_ *bool, _ *uint) [0]C.bool           { return [0]C.bool{} }
-func cntC_uintptr_t(_ *uint, _ *uint) [0]C.uintptr_t { return [0]C.uintptr_t{} }
-func cntC_intptr_t(_ *int, _ *uint) [0]C.intptr_t    { return [0]C.intptr_t{} }
-func cntC_float(_ *float32, _ *uint) [0]C.float      { return [0]C.float{} }
-func cntC_double(_ *float64, _ *uint) [0]C.double    { return [0]C.double{} }
-
-func refC_uint8_t(p *uint8, _ *[]byte) C.uint8_t    { return C.uint8_t(*p) }
-func refC_uint16_t(p *uint16, _ *[]byte) C.uint16_t { return C.uint16_t(*p) }
-func refC_uint32_t(p *uint32, _ *[]byte) C.uint32_t { return C.uint32_t(*p) }
-func refC_uint64_t(p *uint64, _ *[]byte) C.uint64_t { return C.uint64_t(*p) }
-func refC_int8_t(p *int8, _ *[]byte) C.int8_t       { return C.int8_t(*p) }
-func refC_int16_t(p *int16, _ *[]byte) C.int16_t    { return C.int16_t(*p) }
-func refC_int32_t(p *int32, _ *[]byte) C.int32_t    { return C.int32_t(*p) }
-func refC_int64_t(p *int64, _ *[]byte) C.int64_t    { return C.int64_t(*p) }
-func refC_bool(p *bool, _ *[]byte) C.bool           { return C.bool(*p) }
-func refC_uintptr_t(p *uint, _ *[]byte) C.uintptr_t { return C.uintptr_t(*p) }
-func refC_intptr_t(p *int, _ *[]byte) C.intptr_t    { return C.intptr_t(*p) }
-func refC_float(p *float32, _ *[]byte) C.float      { return C.float(*p) }
-func refC_double(p *float64, _ *[]byte) C.double    { return C.double(*p) }
-
-type User struct {
-	id   uint32
-	name string
-	age  uint8
-}
-
-func newUser(p C.UserRef) User {
-	return User{
-		id:   newC_uint32_t(p.id),
-		name: newString(p.name),
-		age:  newC_uint8_t(p.age),
-	}
-}
-func ownUser(p C.UserRef) User {
-	return User{
-		id:   newC_uint32_t(p.id),
-		name: ownString(p.name),
-		age:  newC_uint8_t(p.age),
-	}
 }
 func cntUser(s *User, cnt *uint) [0]C.UserRef {
-	_ = s
-	_ = cnt
-	return [0]C.UserRef{}
+_ = s
+_ = cnt
+return [0]C.UserRef{}
 }
-func refUser(p *User, buffer *[]byte) C.UserRef {
-	return C.UserRef{
-		id:   refC_uint32_t(&p.id, buffer),
-		name: refString(&p.name, buffer),
-		age:  refC_uint8_t(&p.age, buffer),
-	}
+func refUser(p *User, buffer *[]byte) C.UserRef{
+return C.UserRef{
+id: refC_uint32_t(&p.id, buffer),
+name: refString(&p.name, buffer),
+age: refC_uint8_t(&p.age, buffer),
 }
-
+}
 type LoginRequest struct {
-	user     User
-	password string
+    user User
+    password string
 }
-
-func newLoginRequest(p C.LoginRequestRef) LoginRequest {
-	return LoginRequest{
-		user:     newUser(p.user),
-		password: newString(p.password),
-	}
+func newLoginRequest(p C.LoginRequestRef) LoginRequest{
+return LoginRequest{
+user: newUser(p.user),
+password: newString(p.password),
 }
-func ownLoginRequest(p C.LoginRequestRef) LoginRequest {
-	return LoginRequest{
-		user:     ownUser(p.user),
-		password: ownString(p.password),
-	}
+}
+func ownLoginRequest(p C.LoginRequestRef) LoginRequest{
+return LoginRequest{
+user: ownUser(p.user),
+password: ownString(p.password),
+}
 }
 func cntLoginRequest(s *LoginRequest, cnt *uint) [0]C.LoginRequestRef {
-	_ = s
-	_ = cnt
-	return [0]C.LoginRequestRef{}
+_ = s
+_ = cnt
+return [0]C.LoginRequestRef{}
 }
-func refLoginRequest(p *LoginRequest, buffer *[]byte) C.LoginRequestRef {
-	return C.LoginRequestRef{
-		user:     refUser(&p.user, buffer),
-		password: refString(&p.password, buffer),
-	}
+func refLoginRequest(p *LoginRequest, buffer *[]byte) C.LoginRequestRef{
+return C.LoginRequestRef{
+user: refUser(&p.user, buffer),
+password: refString(&p.password, buffer),
 }
-
+}
 type LoginResponse struct {
-	succ    bool
-	message string
-	token   []uint8
+    succ bool
+    message string
+    token []uint8
 }
-
-func newLoginResponse(p C.LoginResponseRef) LoginResponse {
-	return LoginResponse{
-		succ:    newC_bool(p.succ),
-		message: newString(p.message),
-		token:   new_list_mapper_primitive(newC_uint8_t)(p.token),
-	}
+func newLoginResponse(p C.LoginResponseRef) LoginResponse{
+return LoginResponse{
+succ: newC_bool(p.succ),
+message: newString(p.message),
+token: new_list_mapper_primitive(newC_uint8_t)(p.token),
 }
-func ownLoginResponse(p C.LoginResponseRef) LoginResponse {
-	return LoginResponse{
-		succ:    newC_bool(p.succ),
-		message: ownString(p.message),
-		token:   new_list_mapper(newC_uint8_t)(p.token),
-	}
+}
+func ownLoginResponse(p C.LoginResponseRef) LoginResponse{
+return LoginResponse{
+succ: newC_bool(p.succ),
+message: ownString(p.message),
+token: new_list_mapper(newC_uint8_t)(p.token),
+}
 }
 func cntLoginResponse(s *LoginResponse, cnt *uint) [0]C.LoginResponseRef {
-	_ = s
-	_ = cnt
-	return [0]C.LoginResponseRef{}
+_ = s
+_ = cnt
+return [0]C.LoginResponseRef{}
 }
-func refLoginResponse(p *LoginResponse, buffer *[]byte) C.LoginResponseRef {
-	return C.LoginResponseRef{
-		succ:    refC_bool(&p.succ, buffer),
-		message: refString(&p.message, buffer),
-		token:   ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
-	}
+func refLoginResponse(p *LoginResponse, buffer *[]byte) C.LoginResponseRef{
+return C.LoginResponseRef{
+succ: refC_bool(&p.succ, buffer),
+message: refString(&p.message, buffer),
+token: ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
 }
-
+}
 type LogoutRequest struct {
-	token    []uint8
-	user_ids []uint32
+    token []uint8
+    user_ids []uint32
 }
-
-func newLogoutRequest(p C.LogoutRequestRef) LogoutRequest {
-	return LogoutRequest{
-		token:    new_list_mapper_primitive(newC_uint8_t)(p.token),
-		user_ids: new_list_mapper_primitive(newC_uint32_t)(p.user_ids),
-	}
+func newLogoutRequest(p C.LogoutRequestRef) LogoutRequest{
+return LogoutRequest{
+token: new_list_mapper_primitive(newC_uint8_t)(p.token),
+user_ids: new_list_mapper_primitive(newC_uint32_t)(p.user_ids),
 }
-func ownLogoutRequest(p C.LogoutRequestRef) LogoutRequest {
-	return LogoutRequest{
-		token:    new_list_mapper(newC_uint8_t)(p.token),
-		user_ids: new_list_mapper(newC_uint32_t)(p.user_ids),
-	}
+}
+func ownLogoutRequest(p C.LogoutRequestRef) LogoutRequest{
+return LogoutRequest{
+token: new_list_mapper(newC_uint8_t)(p.token),
+user_ids: new_list_mapper(newC_uint32_t)(p.user_ids),
+}
 }
 func cntLogoutRequest(s *LogoutRequest, cnt *uint) [0]C.LogoutRequestRef {
-	_ = s
-	_ = cnt
-	return [0]C.LogoutRequestRef{}
+_ = s
+_ = cnt
+return [0]C.LogoutRequestRef{}
 }
-func refLogoutRequest(p *LogoutRequest, buffer *[]byte) C.LogoutRequestRef {
-	return C.LogoutRequestRef{
-		token:    ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
-		user_ids: ref_list_mapper_primitive(refC_uint32_t)(&p.user_ids, buffer),
-	}
+func refLogoutRequest(p *LogoutRequest, buffer *[]byte) C.LogoutRequestRef{
+return C.LogoutRequestRef{
+token: ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
+user_ids: ref_list_mapper_primitive(refC_uint32_t)(&p.user_ids, buffer),
 }
-
+}
 type FriendsListRequest struct {
-	token    []uint8
-	user_ids []uint32
+    token []uint8
+    user_ids []uint32
 }
-
-func newFriendsListRequest(p C.FriendsListRequestRef) FriendsListRequest {
-	return FriendsListRequest{
-		token:    new_list_mapper_primitive(newC_uint8_t)(p.token),
-		user_ids: new_list_mapper_primitive(newC_uint32_t)(p.user_ids),
-	}
+func newFriendsListRequest(p C.FriendsListRequestRef) FriendsListRequest{
+return FriendsListRequest{
+token: new_list_mapper_primitive(newC_uint8_t)(p.token),
+user_ids: new_list_mapper_primitive(newC_uint32_t)(p.user_ids),
 }
-func ownFriendsListRequest(p C.FriendsListRequestRef) FriendsListRequest {
-	return FriendsListRequest{
-		token:    new_list_mapper(newC_uint8_t)(p.token),
-		user_ids: new_list_mapper(newC_uint32_t)(p.user_ids),
-	}
+}
+func ownFriendsListRequest(p C.FriendsListRequestRef) FriendsListRequest{
+return FriendsListRequest{
+token: new_list_mapper(newC_uint8_t)(p.token),
+user_ids: new_list_mapper(newC_uint32_t)(p.user_ids),
+}
 }
 func cntFriendsListRequest(s *FriendsListRequest, cnt *uint) [0]C.FriendsListRequestRef {
-	_ = s
-	_ = cnt
-	return [0]C.FriendsListRequestRef{}
+_ = s
+_ = cnt
+return [0]C.FriendsListRequestRef{}
 }
-func refFriendsListRequest(p *FriendsListRequest, buffer *[]byte) C.FriendsListRequestRef {
-	return C.FriendsListRequestRef{
-		token:    ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
-		user_ids: ref_list_mapper_primitive(refC_uint32_t)(&p.user_ids, buffer),
-	}
+func refFriendsListRequest(p *FriendsListRequest, buffer *[]byte) C.FriendsListRequestRef{
+return C.FriendsListRequestRef{
+token: ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
+user_ids: ref_list_mapper_primitive(refC_uint32_t)(&p.user_ids, buffer),
 }
-
+}
 type FriendsListResponse struct {
-	users []User
+    users []User
 }
-
-func newFriendsListResponse(p C.FriendsListResponseRef) FriendsListResponse {
-	return FriendsListResponse{
-		users: new_list_mapper(newUser)(p.users),
-	}
+func newFriendsListResponse(p C.FriendsListResponseRef) FriendsListResponse{
+return FriendsListResponse{
+users: new_list_mapper(newUser)(p.users),
 }
-func ownFriendsListResponse(p C.FriendsListResponseRef) FriendsListResponse {
-	return FriendsListResponse{
-		users: new_list_mapper(ownUser)(p.users),
-	}
+}
+func ownFriendsListResponse(p C.FriendsListResponseRef) FriendsListResponse{
+return FriendsListResponse{
+users: new_list_mapper(ownUser)(p.users),
+}
 }
 func cntFriendsListResponse(s *FriendsListResponse, cnt *uint) [0]C.FriendsListResponseRef {
-	cnt_list_mapper(cntUser)(&s.users, cnt)
-	return [0]C.FriendsListResponseRef{}
+cnt_list_mapper(cntUser)(&s.users, cnt)
+return [0]C.FriendsListResponseRef{}
 }
-func refFriendsListResponse(p *FriendsListResponse, buffer *[]byte) C.FriendsListResponseRef {
-	return C.FriendsListResponseRef{
-		users: ref_list_mapper(refUser)(&p.users, buffer),
-	}
+func refFriendsListResponse(p *FriendsListResponse, buffer *[]byte) C.FriendsListResponseRef{
+return C.FriendsListResponseRef{
+users: ref_list_mapper(refUser)(&p.users, buffer),
 }
-
+}
 type PMFriendRequest struct {
-	user_id uint32
-	token   []uint8
-	message string
+    user_id uint32
+    token []uint8
+    message string
 }
-
-func newPMFriendRequest(p C.PMFriendRequestRef) PMFriendRequest {
-	return PMFriendRequest{
-		user_id: newC_uint32_t(p.user_id),
-		token:   new_list_mapper_primitive(newC_uint8_t)(p.token),
-		message: newString(p.message),
-	}
+func newPMFriendRequest(p C.PMFriendRequestRef) PMFriendRequest{
+return PMFriendRequest{
+user_id: newC_uint32_t(p.user_id),
+token: new_list_mapper_primitive(newC_uint8_t)(p.token),
+message: newString(p.message),
 }
-func ownPMFriendRequest(p C.PMFriendRequestRef) PMFriendRequest {
-	return PMFriendRequest{
-		user_id: newC_uint32_t(p.user_id),
-		token:   new_list_mapper(newC_uint8_t)(p.token),
-		message: ownString(p.message),
-	}
+}
+func ownPMFriendRequest(p C.PMFriendRequestRef) PMFriendRequest{
+return PMFriendRequest{
+user_id: newC_uint32_t(p.user_id),
+token: new_list_mapper(newC_uint8_t)(p.token),
+message: ownString(p.message),
+}
 }
 func cntPMFriendRequest(s *PMFriendRequest, cnt *uint) [0]C.PMFriendRequestRef {
-	_ = s
-	_ = cnt
-	return [0]C.PMFriendRequestRef{}
+_ = s
+_ = cnt
+return [0]C.PMFriendRequestRef{}
 }
-func refPMFriendRequest(p *PMFriendRequest, buffer *[]byte) C.PMFriendRequestRef {
-	return C.PMFriendRequestRef{
-		user_id: refC_uint32_t(&p.user_id, buffer),
-		token:   ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
-		message: refString(&p.message, buffer),
-	}
+func refPMFriendRequest(p *PMFriendRequest, buffer *[]byte) C.PMFriendRequestRef{
+return C.PMFriendRequestRef{
+user_id: refC_uint32_t(&p.user_id, buffer),
+token: ref_list_mapper_primitive(refC_uint8_t)(&p.token, buffer),
+message: refString(&p.message, buffer),
 }
-
+}
 type PMFriendResponse struct {
-	succ    bool
-	message string
+    succ bool
+    message string
 }
-
-func newPMFriendResponse(p C.PMFriendResponseRef) PMFriendResponse {
-	return PMFriendResponse{
-		succ:    newC_bool(p.succ),
-		message: newString(p.message),
-	}
+func newPMFriendResponse(p C.PMFriendResponseRef) PMFriendResponse{
+return PMFriendResponse{
+succ: newC_bool(p.succ),
+message: newString(p.message),
 }
-func ownPMFriendResponse(p C.PMFriendResponseRef) PMFriendResponse {
-	return PMFriendResponse{
-		succ:    newC_bool(p.succ),
-		message: ownString(p.message),
-	}
+}
+func ownPMFriendResponse(p C.PMFriendResponseRef) PMFriendResponse{
+return PMFriendResponse{
+succ: newC_bool(p.succ),
+message: ownString(p.message),
+}
 }
 func cntPMFriendResponse(s *PMFriendResponse, cnt *uint) [0]C.PMFriendResponseRef {
-	_ = s
-	_ = cnt
-	return [0]C.PMFriendResponseRef{}
+_ = s
+_ = cnt
+return [0]C.PMFriendResponseRef{}
 }
-func refPMFriendResponse(p *PMFriendResponse, buffer *[]byte) C.PMFriendResponseRef {
-	return C.PMFriendResponseRef{
-		succ:    refC_bool(&p.succ, buffer),
-		message: refString(&p.message, buffer),
-	}
+func refPMFriendResponse(p *PMFriendResponse, buffer *[]byte) C.PMFriendResponseRef{
+return C.PMFriendResponseRef{
+succ: refC_bool(&p.succ, buffer),
+message: refString(&p.message, buffer),
+}
+}
+type PreserveStructAttrsRequest struct {
+    UserId uint64
+    UserName string
+}
+func newPreserveStructAttrsRequest(p C.PreserveStructAttrsRequestRef) PreserveStructAttrsRequest{
+return PreserveStructAttrsRequest{
+UserId: newC_uint64_t(p.UserId),
+UserName: newString(p.UserName),
+}
+}
+func ownPreserveStructAttrsRequest(p C.PreserveStructAttrsRequestRef) PreserveStructAttrsRequest{
+return PreserveStructAttrsRequest{
+UserId: newC_uint64_t(p.UserId),
+UserName: ownString(p.UserName),
+}
+}
+func cntPreserveStructAttrsRequest(s *PreserveStructAttrsRequest, cnt *uint) [0]C.PreserveStructAttrsRequestRef {
+_ = s
+_ = cnt
+return [0]C.PreserveStructAttrsRequestRef{}
+}
+func refPreserveStructAttrsRequest(p *PreserveStructAttrsRequest, buffer *[]byte) C.PreserveStructAttrsRequestRef{
+return C.PreserveStructAttrsRequestRef{
+UserId: refC_uint64_t(&p.UserId, buffer),
+UserName: refString(&p.UserName, buffer),
+}
+}
+type PreserveStructAttrsResponse struct {
+    Success bool
+}
+func newPreserveStructAttrsResponse(p C.PreserveStructAttrsResponseRef) PreserveStructAttrsResponse{
+return PreserveStructAttrsResponse{
+Success: newC_bool(p.Success),
+}
+}
+func ownPreserveStructAttrsResponse(p C.PreserveStructAttrsResponseRef) PreserveStructAttrsResponse{
+return PreserveStructAttrsResponse{
+Success: newC_bool(p.Success),
+}
+}
+func cntPreserveStructAttrsResponse(s *PreserveStructAttrsResponse, cnt *uint) [0]C.PreserveStructAttrsResponseRef {
+_ = s
+_ = cnt
+return [0]C.PreserveStructAttrsResponseRef{}
+}
+func refPreserveStructAttrsResponse(p *PreserveStructAttrsResponse, buffer *[]byte) C.PreserveStructAttrsResponseRef{
+return C.PreserveStructAttrsResponseRef{
+Success: refC_bool(&p.Success, buffer),
+}
 }
 func main() {}

--- a/test/go/gen.go
+++ b/test/go/gen.go
@@ -590,8 +590,8 @@ func refPMFriendResponse(p *PMFriendResponse, buffer *[]byte) C.PMFriendResponse
 }
 
 type PreserveStructAttrsRequest struct {
-	UserId   uint64
-	UserName string
+	UserId   uint64 `json:"user_id" yaml:"userId"`
+	UserName string `json:"user_name" yaml:"userName"`
 }
 
 func newPreserveStructAttrsRequest(p C.PreserveStructAttrsRequestRef) PreserveStructAttrsRequest {
@@ -619,7 +619,7 @@ func refPreserveStructAttrsRequest(p *PreserveStructAttrsRequest, buffer *[]byte
 }
 
 type PreserveStructAttrsResponse struct {
-	Success bool
+	Success bool `json:"success" yaml:"Success"`
 }
 
 func newPreserveStructAttrsResponse(p C.PreserveStructAttrsResponseRef) PreserveStructAttrsResponse {

--- a/test/go/impl.go
+++ b/test/go/impl.go
@@ -172,3 +172,12 @@ func (d *Demo) multi_param_test(user *User, message *string, token *[]uint8) Log
 		token:   *token,
 	}
 }
+
+func (d *Demo) preserve_struct_attrs_test(data *PreserveStructAttrsRequest) PreserveStructAttrsResponse {
+	// Test implementation for preserve_struct_attrs function
+	fmt.Printf("[go] preserve_struct_attrs_test called with data: %+v \n", data)
+
+	return PreserveStructAttrsResponse{
+		Success: true,
+	}
+}

--- a/test/src/user.rs
+++ b/test/src/user.rs
@@ -55,6 +55,9 @@ pub struct PMFriendResponse {
     pub message: String,
 }
 
+/// Supported: snake_case、lowerCamelCase、UpperCamelCase、kebab-case、
+/// SHOUTY_SNAKE_CASE、SHOUTY-KEBAB-CASE、Title Case、Train-Case
+#[rust2go::r2g_struct_tag(json = "snake_case", yaml = "lowerCamelCase")]
 #[allow(non_snake_case)]
 #[derive(rust2go::R2G, Clone)]
 pub struct PreserveStructAttrsRequest {
@@ -62,6 +65,9 @@ pub struct PreserveStructAttrsRequest {
     pub UserName: String,
 }
 
+/// Supported: snake_case、lowerCamelCase、UpperCamelCase、kebab-case、
+/// SHOUTY_SNAKE_CASE、SHOUTY-KEBAB-CASE、Title Case、Train-Case
+#[rust2go::r2g_struct_tag(json = "snake_case", yaml = "UpperCamelCase")]
 #[allow(non_snake_case)]
 #[derive(rust2go::R2G, Clone)]
 pub struct PreserveStructAttrsResponse {

--- a/test/src/user.rs
+++ b/test/src/user.rs
@@ -57,17 +57,16 @@ pub struct PMFriendResponse {
 
 #[allow(non_snake_case)]
 #[derive(rust2go::R2G, Clone)]
-pub struct PreserveStructAttrsRequest{
+pub struct PreserveStructAttrsRequest {
     pub UserId: u64,
     pub UserName: String,
 }
 
 #[allow(non_snake_case)]
 #[derive(rust2go::R2G, Clone)]
-pub struct PreserveStructAttrsResponse{
+pub struct PreserveStructAttrsResponse {
     pub Success: bool,
 }
-
 
 #[rust2go::r2g]
 #[allow(clippy::ptr_arg)]
@@ -85,5 +84,7 @@ pub trait TestCall {
     #[mem_call]
     async fn multi_param_test(user: &User, message: &String, token: &Vec<u8>) -> LoginResponse;
 
-    async fn preserve_struct_attrs_test(data: &PreserveStructAttrsRequest) -> PreserveStructAttrsResponse;
+    async fn preserve_struct_attrs_test(
+        data: &PreserveStructAttrsRequest,
+    ) -> PreserveStructAttrsResponse;
 }

--- a/test/src/user.rs
+++ b/test/src/user.rs
@@ -55,6 +55,20 @@ pub struct PMFriendResponse {
     pub message: String,
 }
 
+#[allow(non_snake_case)]
+#[derive(rust2go::R2G, Clone)]
+pub struct PreserveStructAttrsRequest{
+    pub UserId: u64,
+    pub UserName: String,
+}
+
+#[allow(non_snake_case)]
+#[derive(rust2go::R2G, Clone)]
+pub struct PreserveStructAttrsResponse{
+    pub Success: bool,
+}
+
+
 #[rust2go::r2g]
 #[allow(clippy::ptr_arg)]
 #[allow(dead_code)]
@@ -70,4 +84,6 @@ pub trait TestCall {
     async fn pm_friend(req: PMFriendRequest) -> PMFriendResponse;
     #[mem_call]
     async fn multi_param_test(user: &User, message: &String, token: &Vec<u8>) -> LoginResponse;
+
+    async fn preserve_struct_attrs_test(data: &PreserveStructAttrsRequest) -> PreserveStructAttrsResponse;
 }


### PR DESCRIPTION
feat(macro): Preserve attribute macros on structs
- Retain the original struct's attribute macros in the generated Rust code 
- Ensure attribute macros are correctly applied to the generated structs
- Add parsing and passing logic for struct attributes

feat(rust2go): Add struct field tag generation feature
- Introduce the heck crate for field name conversion
- Implement the r2g_struct_tag macro to support custom struct tags
- Add JSON and YAML tags to generated Go structs
- Support multiple naming conventions: snake_case, camelCase, etc.
- Update test cases to verify tag generation logic
- Export the new r2g_struct_tag macro for external use