### PR TITLE
Update bindgen to 0.72

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.10.0",
  "cexpr",

--- a/rust2go/Cargo.toml
+++ b/rust2go/Cargo.toml
@@ -16,7 +16,7 @@ rust2go-macro = { version = "0.4.1", path = "../rust2go-macro" }
 rust2go-convert = { version = "0.1.1", path = "../rust2go-convert" }
 rust2go-cli = { version = "0.4.2", path = "../rust2go-cli", optional = true }
 
-bindgen = { version = "0.71", optional = true }
+bindgen = { version = "0.72", optional = true }
 syn = { version = "2", features = ["full"], optional = true }
 fs-set-times = { version = "0.20", optional = true }
 


### PR DESCRIPTION
Building for the `aarch64-apple-ios-sim` target does not work using bindgen version 0.71. Clang has renamed the `sim` part of the target triple to `simulator` and shows the following compiler error:

> error: version 'sim' in target triple 'arm64-apple-ios-sim' is invalid

Bindgen version 0.72 fixes this issue with commit https://github.com/rust-lang/rust-bindgen/commit/e5480dd602fa6bb5616d3c435b5b5e4403e6e389.

This pull request updates bindgen to 0.72 in `rust2go/Cargo.toml`.

Fixes #151