### PR TITLE
chore: group dependabot updates into monthly PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,15 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Group all dependabot version updates by ecosystem so that each month only one PR is opened per group:

- `cargo-dependencies`: all Cargo crates
- `github-actions`: all GitHub Actions

This reduces noise from multiple individual dependency PRs.