### PR TITLE
fix: support type aliases in binding files (#172)

### DIFF
--- a/rust2go-common/src/common.rs
+++ b/rust2go-common/src/common.rs
@@ -10,8 +10,8 @@ use quote::{format_ident, quote, ToTokens};
 use std::collections::HashMap;
 use syn::parse::Parser;
 use syn::{
-    Attribute, Error, Expr, ExprLit, File, Ident, Item, Lit, Meta, MetaNameValue, PathSegment,
-    Result, Type,
+    Attribute, Error, Expr, ExprLit, File, FnArg, GenericArgument, Ident, Item, Lit, Meta,
+    MetaNameValue, PathArguments, PathSegment, Result, ReturnType, TraitItem, Type, TypeParamBound,
 };
 
 pub struct RawRsFile {
@@ -21,7 +21,8 @@ pub struct RawRsFile {
 impl RawRsFile {
     pub fn new<S: AsRef<str>>(src: S) -> Self {
         let src = src.as_ref();
-        let syntax = syn::parse_file(src).expect("Unable to parse file");
+        let mut syntax = syn::parse_file(src).expect("Unable to parse file");
+        expand_type_aliases(&mut syntax);
         RawRsFile { file: syntax }
     }
 
@@ -1037,6 +1038,152 @@ impl ParamType {
             }
         }
     }
+
+    // Same as `to_rust_ref`, but renders the ref type as the associated type
+    // `<T as ::rust2go::ToRef>::Ref`. This form also works for type aliases,
+    // which cannot be resolved on the proc-macro side.
+    // The prefix is unused since the types are resolved in the user crate.
+    pub fn to_rust_ref_assoc(&self, prefix: Option<&TokenStream>) -> TokenStream {
+        let _ = prefix;
+        match &self.inner {
+            ParamTypeInner::Primitive(name) => quote!(#name),
+            ParamTypeInner::Custom(name) => {
+                quote!(<#name as ::rust2go::ToRef>::Ref)
+            }
+            ParamTypeInner::List(ty) => {
+                quote!(<#ty as ::rust2go::ToRef>::Ref)
+            }
+        }
+    }
+}
+
+// Expand non-generic type aliases (e.g. `pub type Amount = i64;`) in struct field
+// types and trait method signatures, so the codegen only sees concrete types.
+fn expand_type_aliases(file: &mut File) {
+    // Collect alias definitions. Aliases with generic parameters are not
+    // supported and skipped.
+    let mut aliases = HashMap::<Ident, Type>::new();
+    for item in file.items.iter() {
+        if let Item::Type(t) = item {
+            if t.generics.params.is_empty() {
+                aliases.insert(t.ident.clone(), t.ty.as_ref().clone());
+            }
+        }
+    }
+    if aliases.is_empty() {
+        return;
+    }
+
+    // Resolve alias chains (A -> B -> i64) and detect cycles.
+    let mut resolved = HashMap::<Ident, Type>::new();
+    for name in aliases.keys() {
+        let mut chain = vec![name.clone()];
+        let mut cur = aliases.get(name).unwrap().clone();
+        while let Some(next_ident) =
+            bare_type_ident(&cur).filter(|ident| aliases.contains_key(ident))
+        {
+            if chain.contains(&next_ident) {
+                let mut chain_str = chain
+                    .iter()
+                    .map(|ident| ident.to_string())
+                    .collect::<Vec<_>>();
+                chain_str.push(next_ident.to_string());
+                panic!("cyclic type alias detected: {}", chain_str.join(" -> "));
+            }
+            chain.push(next_ident.clone());
+            cur = aliases.get(&next_ident).unwrap().clone();
+        }
+        resolved.insert(name.clone(), cur);
+    }
+    // Aliases may also be used inside the generic arguments of alias targets
+    // (e.g. `type A = Vec<B>;`), so expand the resolved targets too.
+    let aliases_snapshot = resolved.clone();
+    for ty in resolved.values_mut() {
+        expand_type(ty, &aliases_snapshot);
+    }
+
+    // Expand alias usages in type positions of struct fields and trait methods.
+    for item in file.items.iter_mut() {
+        match item {
+            Item::Struct(s) => {
+                for field in s.fields.iter_mut() {
+                    expand_type(&mut field.ty, &resolved);
+                }
+            }
+            Item::Trait(t) => {
+                for trait_item in t.items.iter_mut() {
+                    if let TraitItem::Fn(f) = trait_item {
+                        for arg in f.sig.inputs.iter_mut() {
+                            if let FnArg::Typed(pat_type) = arg {
+                                expand_type(&mut pat_type.ty, &resolved);
+                            }
+                        }
+                        if let ReturnType::Type(_, ty) = &mut f.sig.output {
+                            expand_type(ty, &resolved);
+                        }
+                    }
+                }
+            }
+            _ => continue,
+        }
+    }
+}
+
+// If the type is a single-segment bare identifier path, return the identifier.
+fn bare_type_ident(ty: &Type) -> Option<Ident> {
+    let Type::Path(p) = ty else {
+        return None;
+    };
+    if p.qself.is_some() || p.path.leading_colon.is_some() || p.path.segments.len() != 1 {
+        return None;
+    }
+    let seg = p.path.segments.first().unwrap();
+    if !seg.arguments.is_none() {
+        return None;
+    }
+    Some(seg.ident.clone())
+}
+
+// Recursively replace alias idents in a type tree. Only type positions are
+// touched: bare single-segment idents and types inside generic arguments.
+fn expand_type(ty: &mut Type, aliases: &HashMap<Ident, Type>) {
+    // Replace the whole type if it is a bare alias ident.
+    if let Some(ident) = bare_type_ident(ty) {
+        if let Some(target) = aliases.get(&ident) {
+            *ty = target.clone();
+            return;
+        }
+    }
+    // Otherwise expand nested types in generic arguments.
+    fn expand_path_args(args: &mut PathArguments, aliases: &HashMap<Ident, Type>) {
+        if let PathArguments::AngleBracketed(args) = args {
+            for arg in args.args.iter_mut() {
+                match arg {
+                    GenericArgument::Type(t) => expand_type(t, aliases),
+                    GenericArgument::AssocType(t) => expand_type(&mut t.ty, aliases),
+                    _ => continue,
+                }
+            }
+        }
+    }
+    match ty {
+        Type::Path(p) => {
+            for seg in p.path.segments.iter_mut() {
+                expand_path_args(&mut seg.arguments, aliases);
+            }
+        }
+        Type::Reference(r) => expand_type(&mut r.elem, aliases),
+        Type::ImplTrait(i) => {
+            for bound in i.bounds.iter_mut() {
+                if let TypeParamBound::Trait(t) = bound {
+                    for seg in t.path.segments.iter_mut() {
+                        expand_path_args(&mut seg.arguments, aliases);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
 }
 
 pub(crate) fn type_to_segment(ty: &Type) -> Result<&PathSegment> {
@@ -1058,6 +1205,67 @@ pub(crate) fn type_to_segment(ty: &Type) -> Result<&PathSegment> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn type_alias_expansion() {
+        let raw = r#"
+        pub type Amount = i64;
+        pub type Money = Amount;
+        pub type Amounts = Vec<Money>;
+        pub struct DemoRequest {
+            pub amount: Amount,
+            pub tips: Vec<Amount>,
+            pub money: Money,
+            pub amounts: Amounts,
+        }
+        pub struct DemoResponse {
+            pub pass: bool,
+        }
+        #[::rust2go::r2g]
+        pub trait DemoCall {
+            fn demo_check(req: DemoRequest, tip: Amount) -> DemoResponse;
+            fn demo_list(amounts: Vec<Amount>) -> Money;
+            fn demo_check_async(req: DemoRequest) -> impl std::future::Future<Output = DemoResponse>;
+        }
+        "#;
+        let raw_file = super::RawRsFile::new(raw);
+        let levels = raw_file.convert_structs_levels().unwrap();
+        let go_structs = raw_file.convert_structs_to_go(&levels, false).unwrap();
+        // Struct fields must be expanded to the aliased primitive types.
+        assert!(go_structs.contains("amount int64"), "{go_structs}");
+        assert!(go_structs.contains("tips []int64"), "{go_structs}");
+        assert!(go_structs.contains("money int64"), "{go_structs}");
+        assert!(go_structs.contains("amounts []int64"), "{go_structs}");
+        assert!(!go_structs.contains("Amount"), "{go_structs}");
+
+        // Ref structs must be generated without alias types.
+        let (_mapping, ref_structs) = raw_file.convert_structs_to_ref().unwrap();
+        let ref_structs = ref_structs.to_string();
+        assert!(!ref_structs.contains("Amount"), "{ref_structs}");
+
+        // Trait method params and return types must be expanded too.
+        let traits = raw_file.convert_r2g_trait().unwrap();
+        let fns = traits.first().unwrap().fns();
+        let demo_check = fns.iter().find(|f| f.name() == "demo_check").unwrap();
+        assert_eq!(demo_check.params()[1].ty().to_go(), "int64");
+        let demo_list = fns.iter().find(|f| f.name() == "demo_list").unwrap();
+        assert_eq!(demo_list.params()[0].ty().to_go(), "[]int64");
+        assert_eq!(demo_list.ret().unwrap().to_go(), "int64");
+        fns.iter().find(|f| f.name() == "demo_check_async").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "cyclic type alias detected")]
+    fn type_alias_cycle() {
+        let raw = r#"
+        pub type A = B;
+        pub type B = A;
+        pub struct S {
+            pub a: A,
+        }
+        "#;
+        super::RawRsFile::new(raw);
+    }
+
     #[test]
     fn it_works() {
         let raw = r#"

--- a/rust2go-common/src/r2g.rs
+++ b/rust2go-common/src/r2g.rs
@@ -735,7 +735,7 @@ impl R2GFnRepr {
 
             let mut body = None;
             if let Some(ret) = self.ret.as_ref() {
-                let resp_ref_ty = ret.to_rust_ref(None);
+                let resp_ref_ty = ret.to_rust_ref_assoc(None);
                 let reqs_ty = self.params().iter().map(|p| &p.ty);
                 let set_result = if self.drop_safe_ret_params {
                     quote! {
@@ -779,7 +779,7 @@ impl R2GFnRepr {
                 // unsafe extern "C" fn demo_check_cb(resp: *const binding::DemoResponseRef, slot: *const ()) {
                 //     *(slot as *mut Option<DemoResponse>) = Some(::rust2go::FromRef::from_ref(::std::mem::transmute(resp)));
                 // }
-                let resp_ref_ty = ret.to_rust_ref(Some(path_prefix));
+                let resp_ref_ty = ret.to_rust_ref_assoc(Some(path_prefix));
                 Ok(quote! {
                     #[allow(clippy::useless_transmute, clippy::transmute_ptr_to_ref)]
                     #[no_mangle]
@@ -796,7 +796,7 @@ impl R2GFnRepr {
                 // ) {
                 //     ::rust2go::SlotWriter::<DemoResponse>::from_ptr(slot).write(::rust2go::FromRef::from_ref(::std::mem::transmute(resp)));
                 // }
-                let resp_ref_ty = ret.to_rust_ref(Some(path_prefix));
+                let resp_ref_ty = ret.to_rust_ref_assoc(Some(path_prefix));
                 let func_param_types = self.params.iter().map(|p| &p.ty);
                 Ok(quote! {
                     #[allow(clippy::useless_transmute, clippy::transmute_ptr_to_ref)]

--- a/rust2go-macro/src/lib.rs
+++ b/rust2go-macro/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 ihciah. All Rights Reserved.
 
 use proc_macro::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 use rust2go_common::{g2r::G2RTraitRepr, r2g::R2GTraitRepr, sbail};
 use syn::{parse::Parser, parse_macro_input, DeriveInput, Ident};
 
@@ -43,9 +43,11 @@ pub fn r2g_derive(input: TokenStream) -> TokenStream {
             | "f32" | "f64" | "bool" | "char" => {
                 ref_fields.push(quote! {#name: #ty});
             }
-            ty => {
-                let ref_type = format_ident!("{ty}Ref");
-                ref_fields.push(quote! {#name: #ref_type});
+            _ => {
+                // Use the associated type form so type aliases also work: the
+                // alias itself cannot be resolved here, but its underlying
+                // type implements `ToRef`.
+                ref_fields.push(quote! {#name: <#ty as ::rust2go::ToRef>::Ref});
             }
         }
     }

--- a/test/go/gen.go
+++ b/test/go/gen.go
@@ -13,6 +13,16 @@ typedef struct ListRef {
   uintptr_t len;
 } ListRef;
 
+typedef struct BalanceRequestRef {
+  uint64_t user_id;
+  struct ListRef friend_ids;
+} BalanceRequestRef;
+
+typedef struct BalanceResponseRef {
+  uint64_t user_id;
+  int64_t balance;
+} BalanceResponseRef;
+
 typedef struct FriendsListRequestRef {
   struct ListRef token;
   struct ListRef user_ids;
@@ -94,6 +104,8 @@ type TestCall interface {
 	multi_param_test(user *User, message *string, token *[]uint8) LoginResponse
 	optional_test(optional *Optional) Optional
 	preserve_struct_attrs_test(data *PreserveStructAttrsRequest) PreserveStructAttrsResponse
+	get_balance(req *BalanceRequest) BalanceResponse
+	transfer(from *uint64, to *uint64) uint64
 }
 
 //export CTestCall_ping
@@ -195,6 +207,31 @@ func CTestCall_preserve_struct_attrs_test(data C.PreserveStructAttrsRequestRef, 
 	go func() {
 		resp := TestCallImpl.preserve_struct_attrs_test(&_new_data)
 		resp_ref, buffer := cvt_ref(cntPreserveStructAttrsResponse, refPreserveStructAttrsResponse)(&resp)
+		asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+		runtime.KeepAlive(resp_ref)
+		runtime.KeepAlive(resp)
+		runtime.KeepAlive(buffer)
+	}()
+}
+
+//export CTestCall_get_balance
+func CTestCall_get_balance(req C.BalanceRequestRef, slot *C.void, cb *C.void) {
+	_new_req := newBalanceRequest(req)
+	resp := TestCallImpl.get_balance(&_new_req)
+	resp_ref, buffer := cvt_ref(cntBalanceResponse, refBalanceResponse)(&resp)
+	asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
+	runtime.KeepAlive(resp_ref)
+	runtime.KeepAlive(resp)
+	runtime.KeepAlive(buffer)
+}
+
+//export CTestCall_transfer
+func CTestCall_transfer(from C.uint64_t, to C.uint64_t, slot *C.void, cb *C.void) {
+	_new_from := newC_uint64_t(from)
+	_new_to := newC_uint64_t(to)
+	go func() {
+		resp := TestCallImpl.transfer(&_new_from, &_new_to)
+		resp_ref, buffer := cvt_ref(cntC_uint64_t, refC_uint64_t)(&resp)
 		asmcall.CallFuncG0P2(unsafe.Pointer(cb), unsafe.Pointer(&resp_ref), unsafe.Pointer(slot))
 		runtime.KeepAlive(resp_ref)
 		runtime.KeepAlive(resp)
@@ -680,6 +717,64 @@ func cntPreserveStructAttrsResponse(s *PreserveStructAttrsResponse, cnt *uint) [
 func refPreserveStructAttrsResponse(p *PreserveStructAttrsResponse, buffer *[]byte) C.PreserveStructAttrsResponseRef {
 	return C.PreserveStructAttrsResponseRef{
 		Success: refC_bool(&p.Success, buffer),
+	}
+}
+
+type BalanceRequest struct {
+	user_id    uint64
+	friend_ids []uint64
+}
+
+func newBalanceRequest(p C.BalanceRequestRef) BalanceRequest {
+	return BalanceRequest{
+		user_id:    newC_uint64_t(p.user_id),
+		friend_ids: new_list_mapper_primitive(newC_uint64_t)(p.friend_ids),
+	}
+}
+func ownBalanceRequest(p C.BalanceRequestRef) BalanceRequest {
+	return BalanceRequest{
+		user_id:    newC_uint64_t(p.user_id),
+		friend_ids: new_list_mapper(newC_uint64_t)(p.friend_ids),
+	}
+}
+func cntBalanceRequest(s *BalanceRequest, cnt *uint) [0]C.BalanceRequestRef {
+	_ = s
+	_ = cnt
+	return [0]C.BalanceRequestRef{}
+}
+func refBalanceRequest(p *BalanceRequest, buffer *[]byte) C.BalanceRequestRef {
+	return C.BalanceRequestRef{
+		user_id:    refC_uint64_t(&p.user_id, buffer),
+		friend_ids: ref_list_mapper_primitive(refC_uint64_t)(&p.friend_ids, buffer),
+	}
+}
+
+type BalanceResponse struct {
+	user_id uint64
+	balance int64
+}
+
+func newBalanceResponse(p C.BalanceResponseRef) BalanceResponse {
+	return BalanceResponse{
+		user_id: newC_uint64_t(p.user_id),
+		balance: newC_int64_t(p.balance),
+	}
+}
+func ownBalanceResponse(p C.BalanceResponseRef) BalanceResponse {
+	return BalanceResponse{
+		user_id: newC_uint64_t(p.user_id),
+		balance: newC_int64_t(p.balance),
+	}
+}
+func cntBalanceResponse(s *BalanceResponse, cnt *uint) [0]C.BalanceResponseRef {
+	_ = s
+	_ = cnt
+	return [0]C.BalanceResponseRef{}
+}
+func refBalanceResponse(p *BalanceResponse, buffer *[]byte) C.BalanceResponseRef {
+	return C.BalanceResponseRef{
+		user_id: refC_uint64_t(&p.user_id, buffer),
+		balance: refC_int64_t(&p.balance, buffer),
 	}
 }
 func main() {}

--- a/test/go/impl.go
+++ b/test/go/impl.go
@@ -181,6 +181,17 @@ func (d *Demo) multi_param_test(user *User, message *string, token *[]uint8) Log
 	}
 }
 
+func (d *Demo) get_balance(req *BalanceRequest) BalanceResponse {
+	return BalanceResponse{
+		user_id: req.user_id,
+		balance: int64(req.user_id) * 100,
+	}
+}
+
+func (d *Demo) transfer(from *uint64, to *uint64) uint64 {
+	return *from + *to
+}
+
 func (d *Demo) preserve_struct_attrs_test(data *PreserveStructAttrsRequest) PreserveStructAttrsResponse {
 	// Test implementation for preserve_struct_attrs function
 	fmt.Printf("[go] preserve_struct_attrs_test called with data: %+v \n", data)

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -362,6 +362,22 @@ mod tests {
         assert!(!response.message.is_empty());
     }
 
+    #[test]
+    fn test_type_alias() {
+        let resp = TestCallImpl::get_balance(&BalanceRequest {
+            user_id: 42,
+            friend_ids: vec![1, 2, 3],
+        });
+        assert_eq!(resp.user_id, 42);
+        assert_eq!(resp.balance, 4200);
+    }
+
+    #[monoio::test(timer_enabled = true)]
+    async fn test_type_alias_async() {
+        let total: UserId = TestCallImpl::transfer(20, 22).await;
+        assert_eq!(total, 42);
+    }
+
     #[monoio::test(timer_enabled = true)]
     async fn test_optional() {
         let req = Optional { optional: None };

--- a/test/src/user.rs
+++ b/test/src/user.rs
@@ -79,6 +79,20 @@ pub struct PreserveStructAttrsResponse {
     pub Success: bool,
 }
 
+pub type UserId = u64;
+
+#[derive(rust2go::R2G, Clone)]
+pub struct BalanceRequest {
+    pub user_id: UserId,
+    pub friend_ids: Vec<UserId>,
+}
+
+#[derive(rust2go::R2G, Clone)]
+pub struct BalanceResponse {
+    pub user_id: UserId,
+    pub balance: i64,
+}
+
 #[rust2go::r2g]
 #[allow(clippy::ptr_arg)]
 #[allow(dead_code)]
@@ -99,4 +113,8 @@ pub trait TestCall {
     async fn preserve_struct_attrs_test(
         data: &PreserveStructAttrsRequest,
     ) -> PreserveStructAttrsResponse;
+
+    fn get_balance(req: &BalanceRequest) -> BalanceResponse;
+    #[drop_safe]
+    async fn transfer(from: UserId, to: UserId) -> UserId;
 }


### PR DESCRIPTION
## Summary

Using a type alias (e.g. `pub type Amount = i64;`) as a parameter or struct field type in an r2g binding file used to crash codegen (`Option::unwrap()` on a `None` in rust2go-common) or emit references to a nonexistent `AmountRef`. This PR makes type aliases work in binding files.

Fixes #172

## Changes

- `rust2go-common/src/common.rs`:
  - `RawRsFile::new` now expands non-generic type aliases at parse time: alias chains are resolved (`type A = B; type B = i64;`), cycles are reported with a clear panic message, and usages are expanded recursively inside generic arguments (e.g. `Vec<Alias>`). Expansion applies to struct field types and trait method params/return types.
  - Added `ParamType::to_rust_ref_assoc`, rendering the ref type as `<T as ::rust2go::ToRef>::Ref` — this form is correct for both concrete types and aliases (the alias shares the underlying type's `ToRef` impl).
  - Unit tests for the expansion (primitives, chains, `Vec<Alias>`, struct fields, trait params/returns).
- `rust2go-common/src/r2g.rs`: use `to_rust_ref_assoc` for response ref types in generated callbacks (3 sites) — the proc-macro side cannot resolve aliases itself.
- `rust2go-macro/src/lib.rs`: `r2g_derive` emits `<#ty as ::rust2go::ToRef>::Ref` for non-primitive ref fields instead of assuming a `{ty}Ref` type name.
- `test/`: end-to-end coverage — `pub type UserId = u64;` used in a struct field (`BalanceRequest`), a sync trait method, and an async `#[drop_safe]` method with bare-alias params/return; Go impl + regenerated bindings + Rust tests.

## Testing

- Reproduced the panic with a minimal case before the fix; after the fix the generated `gen.go` expands alias fields to `uint64_t` and Go signatures use `*uint64`.
- `cargo fmt --check`, `cargo clippy --workspace --all-features --all-targets -- --deny warnings`, and the full test suite (workspace, with mem-ring tested separately due to the known unrelated workspace feature-unification issue) all pass locally.
