### PR TITLE
docs: add codecov badge and sunburst graph to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Rust2Go
 
 [![Crates.io](https://img.shields.io/crates/v/rust2go.svg)](https://crates.io/crates/rust2go)
+[![codecov](https://codecov.io/github/ihciah/rust2go/graph/badge.svg?token=QIID1C79QI)](https://codecov.io/github/ihciah/rust2go)
 
 Rust2Go is a project that provides users with a simple and efficient way to call Golang from Rust with native async support. It also support user calling Rust from Golang.
 
@@ -78,6 +79,10 @@ Note: Since golang may scan the stack, and when it meets peer pointer, it may pa
 ### Extended Features
 
 - [x] Support calling rust from golang
+
+## Coverage
+
+[![codecov sunburst](https://codecov.io/github/ihciah/rust2go/graphs/sunburst.svg?token=QIID1C79QI)](https://codecov.io/github/ihciah/rust2go)
 
 ## Credit
 


### PR DESCRIPTION
## Summary

Add Codecov integration visibility to the README, following up on the code coverage CI added in #173.

## Changes

- Added the Codecov badge next to the existing Crates.io badge
- Added a new `Coverage` section (before `Credit`) embedding the Codecov sunburst graph, linked to the Codecov project page