### PR TITLE
test: add safety-net unit tests and gen.go freshness check (Phase 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,11 @@ jobs:
       # feature set separately.
       - name: Test mem-ring (tokio)
         run: cargo test -p mem-ring --no-default-features --features tokio --all-targets
+      # Building the workspace above regenerates the committed Go bindings
+      # (test/go/gen.go, examples/*/go/gen.go) via build.rs scripts; fail if
+      # the committed copies have drifted from what the .rs sources generate.
+      - name: Check generated Go files are up to date
+        run: git diff --exit-code -- '**/gen.go'
 
   coverage:
     name: coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
       # feature set separately.
       - name: Test mem-ring (tokio)
         run: cargo test -p mem-ring --no-default-features --features tokio --all-targets
+      - name: Test Go packages
+        run: go test ./asmcall/... ./mem-ring/...
       # Building the workspace above regenerates the committed Go bindings
       # (test/go/gen.go, examples/*/go/gen.go) via build.rs scripts; fail if
       # the committed copies have drifted from what the .rs sources generate.

--- a/asmcall/call_test.go
+++ b/asmcall/call_test.go
@@ -1,0 +1,97 @@
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
+
+// Copyright 2024 ihciah. All Rights Reserved.
+
+package asmcall
+
+/*
+#include <stdint.h>
+
+uintptr_t p0_counter = 0;
+
+void reset_counter(void) { p0_counter = 0; }
+void bump_counter(void) { p0_counter += 1; }
+uintptr_t read_counter(void) { return p0_counter; }
+
+void inc_ptr(uintptr_t *p) { *p = *p + 1; }
+void add_to(uintptr_t a, uintptr_t *p) { *p = *p + a; }
+void sum_into(uintptr_t a, uintptr_t b, uintptr_t *out) { *out = a + b; }
+*/
+import "C"
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// The CallFunc* entry points return nothing, so results are observed
+// through a C global (0-arg callees) or an out pointer (1..3-arg callees).
+
+func TestCallFuncG0P0(t *testing.T) {
+	C.reset_counter()
+	CallFuncG0P0(C.bump_counter)
+	CallFuncG0P0(C.bump_counter)
+	if got := uintptr(C.read_counter()); got != 2 {
+		t.Fatalf("counter = %d, want 2", got)
+	}
+}
+
+func TestCallFuncG0P1(t *testing.T) {
+	var v uintptr = 41
+	CallFuncG0P1(C.inc_ptr, unsafe.Pointer(&v))
+	if v != 42 {
+		t.Fatalf("v = %d, want 42", v)
+	}
+}
+
+func TestCallFuncG0P2(t *testing.T) {
+	var v uintptr = 40
+	CallFuncG0P2(C.add_to, unsafe.Pointer(uintptr(2)), unsafe.Pointer(&v))
+	if v != 42 {
+		t.Fatalf("v = %d, want 42", v)
+	}
+}
+
+func TestCallFuncG0P3(t *testing.T) {
+	var out uintptr
+	CallFuncG0P3(C.sum_into, unsafe.Pointer(uintptr(20)), unsafe.Pointer(uintptr(22)), unsafe.Pointer(&out))
+	if out != 42 {
+		t.Fatalf("out = %d, want 42", out)
+	}
+}
+
+// The goroutine-stack (non-G0) variants require callees that use no stack
+// space; all callees above are trivial single-expression functions.
+func TestCallFuncP0(t *testing.T) {
+	C.reset_counter()
+	CallFuncP0(C.bump_counter)
+	if got := uintptr(C.read_counter()); got != 1 {
+		t.Fatalf("counter = %d, want 1", got)
+	}
+}
+
+func TestCallFuncP1(t *testing.T) {
+	var v uintptr = 41
+	CallFuncP1(C.inc_ptr, unsafe.Pointer(&v))
+	if v != 42 {
+		t.Fatalf("v = %d, want 42", v)
+	}
+}
+
+func TestCallFuncP2(t *testing.T) {
+	var v uintptr = 40
+	CallFuncP2(C.add_to, unsafe.Pointer(uintptr(2)), unsafe.Pointer(&v))
+	if v != 42 {
+		t.Fatalf("v = %d, want 42", v)
+	}
+}
+
+func TestCallFuncP3(t *testing.T) {
+	var out uintptr
+	CallFuncP3(C.sum_into, unsafe.Pointer(uintptr(20)), unsafe.Pointer(uintptr(22)), unsafe.Pointer(&out))
+	if out != 42 {
+		t.Fatalf("out = %d, want 42", out)
+	}
+}

--- a/asmcall/calltest/call_test.go
+++ b/asmcall/calltest/call_test.go
@@ -4,7 +4,7 @@
 
 // Copyright 2024 ihciah. All Rights Reserved.
 
-package asmcall
+package calltest
 
 /*
 #include <stdint.h>
@@ -24,6 +24,8 @@ import "C"
 import (
 	"testing"
 	"unsafe"
+
+	"github.com/ihciah/rust2go/asmcall"
 )
 
 // The CallFunc* entry points return nothing, so results are observed
@@ -31,8 +33,8 @@ import (
 
 func TestCallFuncG0P0(t *testing.T) {
 	C.reset_counter()
-	CallFuncG0P0(C.bump_counter)
-	CallFuncG0P0(C.bump_counter)
+	asmcall.CallFuncG0P0(C.bump_counter)
+	asmcall.CallFuncG0P0(C.bump_counter)
 	if got := uintptr(C.read_counter()); got != 2 {
 		t.Fatalf("counter = %d, want 2", got)
 	}
@@ -40,7 +42,7 @@ func TestCallFuncG0P0(t *testing.T) {
 
 func TestCallFuncG0P1(t *testing.T) {
 	var v uintptr = 41
-	CallFuncG0P1(C.inc_ptr, unsafe.Pointer(&v))
+	asmcall.CallFuncG0P1(C.inc_ptr, unsafe.Pointer(&v))
 	if v != 42 {
 		t.Fatalf("v = %d, want 42", v)
 	}
@@ -48,7 +50,7 @@ func TestCallFuncG0P1(t *testing.T) {
 
 func TestCallFuncG0P2(t *testing.T) {
 	var v uintptr = 40
-	CallFuncG0P2(C.add_to, unsafe.Pointer(uintptr(2)), unsafe.Pointer(&v))
+	asmcall.CallFuncG0P2(C.add_to, unsafe.Pointer(uintptr(2)), unsafe.Pointer(&v))
 	if v != 42 {
 		t.Fatalf("v = %d, want 42", v)
 	}
@@ -56,7 +58,7 @@ func TestCallFuncG0P2(t *testing.T) {
 
 func TestCallFuncG0P3(t *testing.T) {
 	var out uintptr
-	CallFuncG0P3(C.sum_into, unsafe.Pointer(uintptr(20)), unsafe.Pointer(uintptr(22)), unsafe.Pointer(&out))
+	asmcall.CallFuncG0P3(C.sum_into, unsafe.Pointer(uintptr(20)), unsafe.Pointer(uintptr(22)), unsafe.Pointer(&out))
 	if out != 42 {
 		t.Fatalf("out = %d, want 42", out)
 	}
@@ -66,7 +68,7 @@ func TestCallFuncG0P3(t *testing.T) {
 // space; all callees above are trivial single-expression functions.
 func TestCallFuncP0(t *testing.T) {
 	C.reset_counter()
-	CallFuncP0(C.bump_counter)
+	asmcall.CallFuncP0(C.bump_counter)
 	if got := uintptr(C.read_counter()); got != 1 {
 		t.Fatalf("counter = %d, want 1", got)
 	}
@@ -74,7 +76,7 @@ func TestCallFuncP0(t *testing.T) {
 
 func TestCallFuncP1(t *testing.T) {
 	var v uintptr = 41
-	CallFuncP1(C.inc_ptr, unsafe.Pointer(&v))
+	asmcall.CallFuncP1(C.inc_ptr, unsafe.Pointer(&v))
 	if v != 42 {
 		t.Fatalf("v = %d, want 42", v)
 	}
@@ -82,7 +84,7 @@ func TestCallFuncP1(t *testing.T) {
 
 func TestCallFuncP2(t *testing.T) {
 	var v uintptr = 40
-	CallFuncP2(C.add_to, unsafe.Pointer(uintptr(2)), unsafe.Pointer(&v))
+	asmcall.CallFuncP2(C.add_to, unsafe.Pointer(uintptr(2)), unsafe.Pointer(&v))
 	if v != 42 {
 		t.Fatalf("v = %d, want 42", v)
 	}
@@ -90,7 +92,7 @@ func TestCallFuncP2(t *testing.T) {
 
 func TestCallFuncP3(t *testing.T) {
 	var out uintptr
-	CallFuncP3(C.sum_into, unsafe.Pointer(uintptr(20)), unsafe.Pointer(uintptr(22)), unsafe.Pointer(&out))
+	asmcall.CallFuncP3(C.sum_into, unsafe.Pointer(uintptr(20)), unsafe.Pointer(uintptr(22)), unsafe.Pointer(&out))
 	if out != 42 {
 		t.Fatalf("out = %d, want 42", out)
 	}

--- a/asmcall/calltest/call_test.go
+++ b/asmcall/calltest/call_test.go
@@ -6,43 +6,26 @@
 
 package calltest
 
-/*
-#include <stdint.h>
-
-uintptr_t p0_counter = 0;
-
-void reset_counter(void) { p0_counter = 0; }
-void bump_counter(void) { p0_counter += 1; }
-uintptr_t read_counter(void) { return p0_counter; }
-
-void inc_ptr(uintptr_t *p) { *p = *p + 1; }
-void add_to(uintptr_t a, uintptr_t *p) { *p = *p + a; }
-void sum_into(uintptr_t a, uintptr_t b, uintptr_t *out) { *out = a + b; }
-*/
-import "C"
-
 import (
 	"testing"
 	"unsafe"
-
-	"github.com/ihciah/rust2go/asmcall"
 )
 
-// The CallFunc* entry points return nothing, so results are observed
-// through a C global (0-arg callees) or an out pointer (1..3-arg callees).
+// The goroutine-stack (non-G0) variants require callees that use no stack
+// space; all callees are trivial single-expression C functions.
 
 func TestCallFuncG0P0(t *testing.T) {
-	C.reset_counter()
-	asmcall.CallFuncG0P0(C.bump_counter)
-	asmcall.CallFuncG0P0(C.bump_counter)
-	if got := uintptr(C.read_counter()); got != 2 {
+	ResetCounter()
+	CallG0P0Bump()
+	CallG0P0Bump()
+	if got := ReadCounter(); got != 2 {
 		t.Fatalf("counter = %d, want 2", got)
 	}
 }
 
 func TestCallFuncG0P1(t *testing.T) {
 	var v uintptr = 41
-	asmcall.CallFuncG0P1(C.inc_ptr, unsafe.Pointer(&v))
+	CallG0P1Inc(unsafe.Pointer(&v))
 	if v != 42 {
 		t.Fatalf("v = %d, want 42", v)
 	}
@@ -50,7 +33,7 @@ func TestCallFuncG0P1(t *testing.T) {
 
 func TestCallFuncG0P2(t *testing.T) {
 	var v uintptr = 40
-	asmcall.CallFuncG0P2(C.add_to, unsafe.Pointer(uintptr(2)), unsafe.Pointer(&v))
+	CallG0P2AddTo(2, unsafe.Pointer(&v))
 	if v != 42 {
 		t.Fatalf("v = %d, want 42", v)
 	}
@@ -58,25 +41,23 @@ func TestCallFuncG0P2(t *testing.T) {
 
 func TestCallFuncG0P3(t *testing.T) {
 	var out uintptr
-	asmcall.CallFuncG0P3(C.sum_into, unsafe.Pointer(uintptr(20)), unsafe.Pointer(uintptr(22)), unsafe.Pointer(&out))
+	CallG0P3SumInto(20, 22, unsafe.Pointer(&out))
 	if out != 42 {
 		t.Fatalf("out = %d, want 42", out)
 	}
 }
 
-// The goroutine-stack (non-G0) variants require callees that use no stack
-// space; all callees above are trivial single-expression functions.
 func TestCallFuncP0(t *testing.T) {
-	C.reset_counter()
-	asmcall.CallFuncP0(C.bump_counter)
-	if got := uintptr(C.read_counter()); got != 1 {
+	ResetCounter()
+	CallP0Bump()
+	if got := ReadCounter(); got != 1 {
 		t.Fatalf("counter = %d, want 1", got)
 	}
 }
 
 func TestCallFuncP1(t *testing.T) {
 	var v uintptr = 41
-	asmcall.CallFuncP1(C.inc_ptr, unsafe.Pointer(&v))
+	CallP1Inc(unsafe.Pointer(&v))
 	if v != 42 {
 		t.Fatalf("v = %d, want 42", v)
 	}
@@ -84,7 +65,7 @@ func TestCallFuncP1(t *testing.T) {
 
 func TestCallFuncP2(t *testing.T) {
 	var v uintptr = 40
-	asmcall.CallFuncP2(C.add_to, unsafe.Pointer(uintptr(2)), unsafe.Pointer(&v))
+	CallP2AddTo(2, unsafe.Pointer(&v))
 	if v != 42 {
 		t.Fatalf("v = %d, want 42", v)
 	}
@@ -92,7 +73,7 @@ func TestCallFuncP2(t *testing.T) {
 
 func TestCallFuncP3(t *testing.T) {
 	var out uintptr
-	asmcall.CallFuncP3(C.sum_into, unsafe.Pointer(uintptr(20)), unsafe.Pointer(uintptr(22)), unsafe.Pointer(&out))
+	CallP3SumInto(20, 22, unsafe.Pointer(&out))
 	if out != 42 {
 		t.Fatalf("out = %d, want 42", out)
 	}

--- a/asmcall/calltest/calltest.go
+++ b/asmcall/calltest/calltest.go
@@ -1,0 +1,63 @@
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
+
+// Copyright 2024 ihciah. All Rights Reserved.
+
+// Package calltest provides cgo wrappers used by the asmcall correctness
+// tests. The cgo preamble and all C symbol references must live in this
+// non-test file: cgo is not supported in test-only packages (the go tool
+// rejects "use of cgo in test" when a package has no non-test Go files).
+package calltest
+
+/*
+#include <stdint.h>
+
+uintptr_t p0_counter = 0;
+
+void reset_counter(void) { p0_counter = 0; }
+void bump_counter(void) { p0_counter += 1; }
+uintptr_t read_counter(void) { return p0_counter; }
+
+void inc_ptr(uintptr_t *p) { *p = *p + 1; }
+void add_to(uintptr_t a, uintptr_t *p) { *p = *p + a; }
+void sum_into(uintptr_t a, uintptr_t b, uintptr_t *out) { *out = a + b; }
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/ihciah/rust2go/asmcall"
+)
+
+// The CallFunc* entry points return nothing, so results are observed
+// through a C global (0-arg callees) or an out pointer (1..3-arg callees).
+
+func ResetCounter() { C.reset_counter() }
+
+func ReadCounter() uintptr { return uintptr(C.read_counter()) }
+
+func CallG0P0Bump() { asmcall.CallFuncG0P0(C.bump_counter) }
+
+func CallP0Bump() { asmcall.CallFuncP0(C.bump_counter) }
+
+func CallG0P1Inc(p unsafe.Pointer) { asmcall.CallFuncG0P1(C.inc_ptr, p) }
+
+func CallP1Inc(p unsafe.Pointer) { asmcall.CallFuncP1(C.inc_ptr, p) }
+
+func CallG0P2AddTo(a uintptr, p unsafe.Pointer) {
+	asmcall.CallFuncG0P2(C.add_to, unsafe.Pointer(a), p)
+}
+
+func CallP2AddTo(a uintptr, p unsafe.Pointer) {
+	asmcall.CallFuncP2(C.add_to, unsafe.Pointer(a), p)
+}
+
+func CallG0P3SumInto(a, b uintptr, out unsafe.Pointer) {
+	asmcall.CallFuncG0P3(C.sum_into, unsafe.Pointer(a), unsafe.Pointer(b), out)
+}
+
+func CallP3SumInto(a, b uintptr, out unsafe.Pointer) {
+	asmcall.CallFuncP3(C.sum_into, unsafe.Pointer(a), unsafe.Pointer(b), out)
+}

--- a/mem-ring/queue.go
+++ b/mem-ring/queue.go
@@ -159,6 +159,9 @@ func (q Queue[T]) Write() WriteQueue[T] {
 			if !wq.pendingTasks.IsEmpty() {
 				wq.q.markStuck()
 				if !wq.q.isFull() {
+					// Unlock before continue: jumping back to the loop top
+					// while holding the lock would self-deadlock.
+					wq.Lock.Unlock()
 					continue
 				}
 			}

--- a/mem-ring/queue_test.go
+++ b/mem-ring/queue_test.go
@@ -1,0 +1,196 @@
+// Copyright 2024 ihciah. All Rights Reserved.
+
+package mem_ring
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// newTestQueue builds a Queue over locally allocated memory so the pure
+// ring arithmetic can be tested without socketpairs/eventfd.
+// The returned slice keeps the backing buffer alive.
+func newTestQueue[T any](n int) (*Queue[T], []T) {
+	buf := make([]T, n)
+	var head, tail uint64
+	var working, stuck uint32
+	q := &Queue[T]{
+		bufferPtr:  unsafe.Pointer(&buf[0]),
+		bufferLen:  uintptr(n),
+		headPtr:    &head,
+		tailPtr:    &tail,
+		workingPtr: &working,
+		stuckPtr:   &stuck,
+	}
+	return q, buf
+}
+
+func TestQueueEmptyPopReturnsNil(t *testing.T) {
+	q, _ := newTestQueue[uint64](4)
+	if !q.isEmpty() {
+		t.Fatal("new queue is not empty")
+	}
+	if item := q.pop(); item != nil {
+		t.Fatalf("pop on empty queue = %v, want nil", *item)
+	}
+}
+
+func TestQueuePushUntilFull(t *testing.T) {
+	q, _ := newTestQueue[uint64](4)
+	for i := uint64(0); i < 4; i++ {
+		if !q.push(i) {
+			t.Fatalf("push(%d) failed on non-full queue", i)
+		}
+	}
+	if !q.isFull() {
+		t.Fatal("queue not full after 4 pushes into buffer of 4")
+	}
+	if q.push(4) {
+		t.Fatal("push succeeded on full queue")
+	}
+}
+
+func TestQueuePopFIFOOrder(t *testing.T) {
+	q, _ := newTestQueue[uint64](4)
+	for i := uint64(0); i < 4; i++ {
+		q.push(i * 11)
+	}
+	for i := uint64(0); i < 4; i++ {
+		item := q.pop()
+		if item == nil {
+			t.Fatalf("pop %d returned nil", i)
+		}
+		if *item != i*11 {
+			t.Fatalf("pop %d = %d, want %d", i, *item, i*11)
+		}
+	}
+	if !q.isEmpty() {
+		t.Fatal("queue not empty after popping all items")
+	}
+	if item := q.pop(); item != nil {
+		t.Fatalf("pop on drained queue = %v, want nil", *item)
+	}
+}
+
+// Interleaved push/pop must wrap around the buffer via modulo indexing.
+func TestQueueWrapAround(t *testing.T) {
+	q, _ := newTestQueue[uint64](4)
+	for i := uint64(0); i < 100; i++ {
+		if !q.push(i) {
+			t.Fatalf("push(%d) failed", i)
+		}
+		item := q.pop()
+		if item == nil || *item != i {
+			t.Fatalf("iteration %d: pop = %v, want %d", i, item, i)
+		}
+	}
+	if !q.isEmpty() {
+		t.Fatal("queue not empty after interleaved push/pop")
+	}
+}
+
+// Fill, drain partially, refill: head/tail keep advancing past bufferLen.
+func TestQueueRefillAfterDrain(t *testing.T) {
+	q, _ := newTestQueue[uint64](4)
+	var next uint64
+	push := func() {
+		if !q.push(next) {
+			t.Fatalf("push(%d) failed", next)
+		}
+		next++
+	}
+	popWant := func(want uint64) {
+		item := q.pop()
+		if item == nil || *item != want {
+			t.Fatalf("pop = %v, want %d", item, want)
+		}
+	}
+	for i := 0; i < 4; i++ {
+		push()
+	}
+	if q.push(next) {
+		t.Fatal("push succeeded on full queue")
+	}
+	for round := uint64(0); round < 10; round++ {
+		popWant(round * 2)
+		popWant(round*2 + 1)
+		push()
+		push()
+	}
+}
+
+func TestQueueWorkingFlags(t *testing.T) {
+	q, _ := newTestQueue[uint64](2)
+	if q.working() {
+		t.Fatal("new queue is working")
+	}
+	q.markWorking()
+	if !q.working() {
+		t.Fatal("working() false after markWorking")
+	}
+	// Empty queue: markUnworking clears the flag and reports done.
+	if !q.markUnworking() {
+		t.Fatal("markUnworking on empty queue returned false")
+	}
+	if q.working() {
+		t.Fatal("working() true after markUnworking on empty queue")
+	}
+	// Non-empty queue: markUnworking re-marks working and reports not done.
+	q.push(7)
+	q.markWorking()
+	if q.markUnworking() {
+		t.Fatal("markUnworking on non-empty queue returned true")
+	}
+	if !q.working() {
+		t.Fatal("working() false after markUnworking on non-empty queue")
+	}
+}
+
+func TestQueueStuckFlags(t *testing.T) {
+	q, _ := newTestQueue[uint64](2)
+	if q.stuck() {
+		t.Fatal("new queue is stuck")
+	}
+	q.markStuck()
+	if !q.stuck() {
+		t.Fatal("stuck() false after markStuck")
+	}
+	q.markUnstuck()
+	if q.stuck() {
+		t.Fatal("stuck() true after markUnstuck")
+	}
+}
+
+// NewQueue must wire QueueMeta pointers up the same way as manual
+// construction (fds are irrelevant for push/pop and left unset).
+func TestNewQueueFromMeta(t *testing.T) {
+	const n = 8
+	buf := make([]uint64, n)
+	var head, tail uint64
+	var working, stuck uint32
+	q := NewQueue[uint64](QueueMeta{
+		BufferPtr:  uintptr(unsafe.Pointer(&buf[0])),
+		BufferLen:  n,
+		HeadPtr:    uintptr(unsafe.Pointer(&head)),
+		TailPtr:    uintptr(unsafe.Pointer(&tail)),
+		WorkingPtr: uintptr(unsafe.Pointer(&working)),
+		StuckPtr:   uintptr(unsafe.Pointer(&stuck)),
+	})
+	for i := uint64(0); i < n; i++ {
+		if !q.push(i + 100) {
+			t.Fatalf("push(%d) failed", i)
+		}
+	}
+	if !q.isFull() {
+		t.Fatal("queue not full")
+	}
+	for i := uint64(0); i < n; i++ {
+		item := q.pop()
+		if item == nil || *item != i+100 {
+			t.Fatalf("pop %d = %v, want %d", i, item, i+100)
+		}
+	}
+	if head != n || tail != n {
+		t.Fatalf("head/tail = %d/%d, want %d/%d", head, tail, n, n)
+	}
+}

--- a/mem-ring/slab.go
+++ b/mem-ring/slab.go
@@ -7,6 +7,10 @@ import (
 	"sync/atomic"
 )
 
+// freelistEmpty is the sentinel for an empty freelist.
+// It must not be a valid slot index (0 was a bug: slot 0 could never be reused).
+const freelistEmpty = ^uint(0)
+
 // Note: T should be Copy
 type Item[T any] struct {
 	next uint
@@ -33,7 +37,7 @@ type MultiSlab[T any] struct {
 func NewSlab[T any]() *Slab[T] {
 	return &Slab[T]{
 		data: make([]Item[T], 0, 1),
-		next: 0,
+		next: freelistEmpty,
 	}
 }
 
@@ -74,15 +78,15 @@ type MultiSlabOption interface {
 }
 
 func (s *Slab[T]) Push(data T) uint {
-	if s.next == 0 {
-		s.data = append(s.data, Item[T]{next: 0, data: data})
+	if s.next == freelistEmpty {
+		s.data = append(s.data, Item[T]{next: freelistEmpty, data: data})
 		return uint(len(s.data) - 1)
 	}
 	index := s.next
 	item := &s.data[index]
 	item.data = data
 	s.next = item.next
-	item.next = 0
+	item.next = freelistEmpty
 	return index
 }
 
@@ -99,10 +103,16 @@ func (s *MultiSlab[T]) Push(data T) uint {
 }
 
 func (s *Slab[T]) Pop(index uint) T {
+	if index >= uint(len(s.data)) {
+		panic("mem_ring: Slab.Pop index out of range")
+	}
 	item := &s.data[index]
+	data := item.data
+	var zero T
+	item.data = zero // clear the reference so GC can reclaim it
 	item.next = s.next
 	s.next = index
-	return item.data
+	return data
 }
 
 func (s *LockedSlab[T]) Pop(index uint) T {

--- a/mem-ring/slab_test.go
+++ b/mem-ring/slab_test.go
@@ -1,0 +1,196 @@
+// Copyright 2024 ihciah. All Rights Reserved.
+
+package mem_ring
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestSlabPushAllocatesSequentialIndexes(t *testing.T) {
+	s := NewSlab[int]()
+	for i := 0; i < 10; i++ {
+		idx := s.Push(i)
+		if idx != uint(i) {
+			t.Fatalf("Push(%d) returned index %d, want %d", i, idx, i)
+		}
+	}
+}
+
+func TestSlabPushPopRoundTrip(t *testing.T) {
+	s := NewSlab[int]()
+	for i := 0; i < 10; i++ {
+		s.Push(i * 7)
+	}
+	for i := 0; i < 10; i++ {
+		if got := s.Pop(uint(i)); got != i*7 {
+			t.Fatalf("Pop(%d) = %d, want %d", i, got, i*7)
+		}
+	}
+}
+
+// Slot 0 must be reusable: the freelist used to treat index 0 as the
+// "empty" sentinel, so slot 0 was never handed out again after Pop.
+func TestSlabSlotZeroReuse(t *testing.T) {
+	s := NewSlab[int]()
+	idx0 := s.Push(100)
+	idx1 := s.Push(200)
+	if idx0 != 0 || idx1 != 1 {
+		t.Fatalf("initial indexes = %d, %d, want 0, 1", idx0, idx1)
+	}
+	if got := s.Pop(idx0); got != 100 {
+		t.Fatalf("Pop(%d) = %d, want 100", idx0, got)
+	}
+	if idx := s.Push(300); idx != 0 {
+		t.Fatalf("Push after Pop(0) reused index %d, want 0", idx)
+	}
+	if got := s.Pop(0); got != 300 {
+		t.Fatalf("Pop(0) = %d, want 300", got)
+	}
+	if got := s.Pop(1); got != 200 {
+		t.Fatalf("Pop(1) = %d, want 200", got)
+	}
+}
+
+// Popped slots are recycled in LIFO order through the freelist.
+func TestSlabFreelistReuseOrder(t *testing.T) {
+	s := NewSlab[int]()
+	for i := 0; i < 3; i++ {
+		s.Push(i)
+	}
+	for i := 0; i < 3; i++ {
+		s.Pop(uint(i))
+	}
+	// Freelist after popping 0,1,2 is 2 -> 1 -> 0.
+	want := []uint{2, 1, 0}
+	for i, w := range want {
+		if idx := s.Push(100 + i); idx != w {
+			t.Fatalf("reuse push %d got index %d, want %d", i, idx, w)
+		}
+	}
+}
+
+// Pop must zero the stored item so the GC can reclaim referenced objects.
+func TestSlabPopClearsReference(t *testing.T) {
+	s := NewSlab[*int]()
+	v := 42
+	idx := s.Push(&v)
+	if got := s.Pop(idx); got != &v {
+		t.Fatalf("Pop(%d) = %v, want %v", idx, got, &v)
+	}
+	if s.data[idx].data != nil {
+		t.Fatalf("slot %d still holds a reference after Pop", idx)
+	}
+}
+
+func TestSlabPopOutOfBoundsPanics(t *testing.T) {
+	s := NewSlab[int]()
+	s.Push(1)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Pop with out-of-range index did not panic")
+		}
+	}()
+	s.Pop(5)
+}
+
+func TestLockedSlabRoundTrip(t *testing.T) {
+	s := NewLockedSlab[int]()
+	var idxs [16]uint
+	for i := 0; i < 16; i++ {
+		idxs[i] = s.Push(i * 3)
+	}
+	for i := 0; i < 16; i++ {
+		if got := s.Pop(idxs[i]); got != i*3 {
+			t.Fatalf("Pop(%d) = %d, want %d", idxs[i], got, i*3)
+		}
+	}
+	// Freelist is LIFO: the last popped slot (15) is reused first.
+	if idx := s.Push(1000); idx != 15 {
+		t.Fatalf("Push after popping all returned %d, want 15", idx)
+	}
+}
+
+func TestLockedSlabConcurrentPushPop(t *testing.T) {
+	s := NewLockedSlab[int]()
+	const workers = 8
+	const perWorker = 200
+	var wg sync.WaitGroup
+	errCh := make(chan string, workers)
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(base int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				idx := s.Push(base + i)
+				if got := s.Pop(idx); got != base+i {
+					errCh <- "value mismatch"
+					return
+				}
+			}
+		}(w * perWorker)
+	}
+	wg.Wait()
+	close(errCh)
+	for msg := range errCh {
+		t.Fatal(msg)
+	}
+}
+
+func TestMultiSlabRoundTrip(t *testing.T) {
+	s := NewMultiSlab[int]()
+	const n = 64
+	idxs := make([]uint, n)
+	for i := 0; i < n; i++ {
+		idxs[i] = s.Push(i * 5)
+	}
+	for i := 0; i < n; i++ {
+		if got := s.Pop(idxs[i]); got != i*5 {
+			t.Fatalf("Pop(%d) = %d, want %d", idxs[i], got, i*5)
+		}
+	}
+}
+
+// Pushes must be spread over the inner slabs: the low `exp` bits of the
+// returned index select the slab, the high bits are the inner index.
+func TestMultiSlabIndexDistribution(t *testing.T) {
+	s := NewMultiSlab[int]() // default exp = 4, 16 slabs
+	const n = 64
+	seen := make(map[uint]struct{})
+	for i := 0; i < n; i++ {
+		idx := s.Push(i)
+		seen[idx&s.mask] = struct{}{}
+		if inner := idx >> s.exp; inner != 0 && inner != 1 && inner != 2 && inner != 3 {
+			t.Fatalf("inner index %d unexpectedly large after %d pushes", inner, i+1)
+		}
+	}
+	if len(seen) < 2 {
+		t.Fatalf("all %d pushes landed on a single slab", n)
+	}
+}
+
+// After popping every slot of an inner slab, the next push routed to that
+// slab must reuse the freed inner index (including inner index 0).
+func TestMultiSlabSlotReuse(t *testing.T) {
+	s := NewMultiSlab[int]()
+	const n = 16
+	first := make([]uint, n)
+	for i := 0; i < n; i++ {
+		first[i] = s.Push(i)
+	}
+	for i := 0; i < n; i++ {
+		s.Pop(first[i])
+	}
+	// Round-robin routing returns to each slab in the same order; every
+	// slab's freelist head is its just-freed slot, so indexes repeat.
+	for i := 0; i < n; i++ {
+		if idx := s.Push(1000 + i); idx != first[i] {
+			t.Fatalf("reuse push %d got index %d, want %d", i, idx, first[i])
+		}
+	}
+	for i := 0; i < n; i++ {
+		if got := s.Pop(first[i]); got != 1000+i {
+			t.Fatalf("Pop(%d) = %d, want %d", first[i], got, 1000+i)
+		}
+	}
+}

--- a/rust2go-common/src/common.rs
+++ b/rust2go-common/src/common.rs
@@ -1362,7 +1362,10 @@ mod tests {
         assert!(go.contains("return DemoRequest{"), "{go}");
         assert!(go.contains("name: newString(p.name),"), "{go}");
         assert!(go.contains("age: newC_uint8_t(p.age),"), "{go}");
-        assert!(go.contains("tags: new_list_mapper(newString)(p.tags),"), "{go}");
+        assert!(
+            go.contains("tags: new_list_mapper(newString)(p.tags),"),
+            "{go}"
+        );
         assert!(
             go.contains("scores: new_list_mapper_primitive(newC_uint32_t)(p.scores),"),
             "{go}"
@@ -1399,7 +1402,10 @@ mod tests {
             go.contains("func cntDemoRequest(s *DemoRequest, cnt *uint) [0]C.DemoRequestRef {"),
             "{go}"
         );
-        assert!(go.contains("cnt_list_mapper(cntString)(&s.tags, cnt)"), "{go}");
+        assert!(
+            go.contains("cnt_list_mapper(cntString)(&s.tags, cnt)"),
+            "{go}"
+        );
         assert!(
             go.contains("func cntDemoNested(s *DemoNested, cnt *uint) [0]C.DemoNestedRef {"),
             "{go}"
@@ -1426,14 +1432,22 @@ mod tests {
             "{go}"
         );
         assert!(
-            go.contains("nested_list: ref_list_mapper_primitive(refDemoNested)(&p.nested_list, buffer),"),
+            go.contains(
+                "nested_list: ref_list_mapper_primitive(refDemoNested)(&p.nested_list, buffer),"
+            ),
             "{go}"
         );
 
         // Common helpers preamble (go1.21+ variant).
-        assert!(go.contains("func newString(s_ref C.StringRef) string {"), "{go}");
+        assert!(
+            go.contains("func newString(s_ref C.StringRef) string {"),
+            "{go}"
+        );
         assert!(go.contains("unsafe.StringData"), "{go}");
-        assert!(go.contains("func ownString(s_ref C.StringRef) string {"), "{go}");
+        assert!(
+            go.contains("func ownString(s_ref C.StringRef) string {"),
+            "{go}"
+        );
         assert!(
             go.contains("func new_list_mapper[T1, T2 any](f func(T1) T2) func(C.ListRef) []T2 {"),
             "{go}"
@@ -1461,7 +1475,10 @@ mod tests {
         assert_eq!(mapping[&ident("Vec")].to_string(), "ListRef");
         assert_eq!(mapping[&ident("DemoNested")].to_string(), "DemoNestedRef");
         assert_eq!(mapping[&ident("DemoRequest")].to_string(), "DemoRequestRef");
-        assert_eq!(mapping[&ident("DemoResponse")].to_string(), "DemoResponseRef");
+        assert_eq!(
+            mapping[&ident("DemoResponse")].to_string(),
+            "DemoResponseRef"
+        );
 
         // Generated #[repr(C)] ref structs.
         let norm = normalize_tokens(ref_structs);
@@ -1510,7 +1527,10 @@ mod tests {
         let go = raw_file.convert_structs_to_go(&levels, false).unwrap();
         assert!(go.contains("type TaggedUser struct {"), "{go}");
         assert!(go.contains("user_name string `json:\"user_name\"`"), "{go}");
-        assert!(go.contains("login_count uint32 `json:\"login_count\"`"), "{go}");
+        assert!(
+            go.contains("login_count uint32 `json:\"login_count\"`"),
+            "{go}"
+        );
     }
 
     #[test]
@@ -1655,7 +1675,10 @@ mod tests {
             pt.c_to_go_field_converter(&levels),
             ("new_list_mapper(newString)".to_string(), 2)
         );
-        assert_eq!(pt.c_to_go_field_converter_owned(), "new_list_mapper(ownString)");
+        assert_eq!(
+            pt.c_to_go_field_converter_owned(),
+            "new_list_mapper(ownString)"
+        );
         assert_eq!(
             pt.go_to_c_field_counter(&levels),
             ("cnt_list_mapper(cntString)".to_string(), 2)

--- a/rust2go-common/src/common.rs
+++ b/rust2go-common/src/common.rs
@@ -1296,4 +1296,384 @@ mod tests {
         let levels = raw_file.convert_structs_levels().unwrap();
         levels.iter().for_each(|f| println!("{}: {}", f.0, f.1));
     }
+
+    const DEMO_SRC: &str = r#"
+    pub struct DemoNested {
+        pub id: u32,
+        pub score: f64,
+    }
+    pub struct DemoRequest {
+        pub name: String,
+        pub age: u8,
+        pub tags: Vec<String>,
+        pub scores: Vec<u32>,
+        pub maybe_count: Option<u32>,
+        pub nested: DemoNested,
+        pub nested_list: Vec<DemoNested>,
+    }
+    pub struct DemoResponse {
+        pub pass: bool,
+    }
+    "#;
+
+    fn ident(name: &str) -> proc_macro2::Ident {
+        proc_macro2::Ident::new(name, proc_macro2::Span::call_site())
+    }
+
+    fn param_type(src: &str) -> super::ParamType {
+        let ty: syn::Type = syn::parse_str(src).expect("unable to parse type");
+        super::ParamType::try_from(&ty).expect("unable to convert type")
+    }
+
+    fn normalize_tokens(tokens: proc_macro2::TokenStream) -> String {
+        tokens
+            .to_string()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    #[test]
+    fn go_struct_generation_golden() {
+        let raw_file = super::RawRsFile::new(DEMO_SRC);
+        let levels = raw_file.convert_structs_levels().unwrap();
+        let go = raw_file.convert_structs_to_go(&levels, false).unwrap();
+
+        // Go struct definitions with converted field types.
+        assert!(go.contains("type DemoNested struct {"), "{go}");
+        assert!(go.contains("id uint32"), "{go}");
+        assert!(go.contains("score float64"), "{go}");
+        assert!(go.contains("type DemoRequest struct {"), "{go}");
+        assert!(go.contains("name string"), "{go}");
+        assert!(go.contains("age uint8"), "{go}");
+        assert!(go.contains("tags []string"), "{go}");
+        assert!(go.contains("scores []uint32"), "{go}");
+        assert!(go.contains("maybe_count []uint32"), "{go}");
+        assert!(go.contains("nested DemoNested"), "{go}");
+        assert!(go.contains("nested_list []DemoNested"), "{go}");
+        assert!(go.contains("type DemoResponse struct {"), "{go}");
+        assert!(go.contains("pass bool"), "{go}");
+
+        // newStruct: C ref -> Go struct converters.
+        assert!(
+            go.contains("func newDemoRequest(p C.DemoRequestRef) DemoRequest{"),
+            "{go}"
+        );
+        assert!(go.contains("return DemoRequest{"), "{go}");
+        assert!(go.contains("name: newString(p.name),"), "{go}");
+        assert!(go.contains("age: newC_uint8_t(p.age),"), "{go}");
+        assert!(go.contains("tags: new_list_mapper(newString)(p.tags),"), "{go}");
+        assert!(
+            go.contains("scores: new_list_mapper_primitive(newC_uint32_t)(p.scores),"),
+            "{go}"
+        );
+        assert!(
+            go.contains("maybe_count: new_list_mapper_primitive(newC_uint32_t)(p.maybe_count),"),
+            "{go}"
+        );
+        assert!(go.contains("nested: newDemoNested(p.nested),"), "{go}");
+        assert!(
+            go.contains("nested_list: new_list_mapper_primitive(newDemoNested)(p.nested_list),"),
+            "{go}"
+        );
+        assert!(
+            go.contains("func newDemoNested(p C.DemoNestedRef) DemoNested{"),
+            "{go}"
+        );
+        assert!(go.contains("id: newC_uint32_t(p.id),"), "{go}");
+        assert!(go.contains("score: newC_double(p.score),"), "{go}");
+
+        // ownStruct: C ref -> Go struct with full ownership.
+        assert!(
+            go.contains("func ownDemoRequest(p C.DemoRequestRef) DemoRequest{"),
+            "{go}"
+        );
+        assert!(go.contains("name: ownString(p.name),"), "{go}");
+        assert!(
+            go.contains("tags: new_list_mapper(ownString)(p.tags),"),
+            "{go}"
+        );
+
+        // cntStruct: only level-2 fields are counted.
+        assert!(
+            go.contains("func cntDemoRequest(s *DemoRequest, cnt *uint) [0]C.DemoRequestRef {"),
+            "{go}"
+        );
+        assert!(go.contains("cnt_list_mapper(cntString)(&s.tags, cnt)"), "{go}");
+        assert!(
+            go.contains("func cntDemoNested(s *DemoNested, cnt *uint) [0]C.DemoNestedRef {"),
+            "{go}"
+        );
+
+        // refStruct: Go struct -> C ref converters.
+        assert!(
+            go.contains("func refDemoRequest(p *DemoRequest, buffer *[]byte) C.DemoRequestRef{"),
+            "{go}"
+        );
+        assert!(go.contains("return C.DemoRequestRef{"), "{go}");
+        assert!(go.contains("name: refString(&p.name, buffer),"), "{go}");
+        assert!(go.contains("age: refC_uint8_t(&p.age, buffer),"), "{go}");
+        assert!(
+            go.contains("tags: ref_list_mapper(refString)(&p.tags, buffer),"),
+            "{go}"
+        );
+        assert!(
+            go.contains("scores: ref_list_mapper_primitive(refC_uint32_t)(&p.scores, buffer),"),
+            "{go}"
+        );
+        assert!(
+            go.contains("nested: refDemoNested(&p.nested, buffer),"),
+            "{go}"
+        );
+        assert!(
+            go.contains("nested_list: ref_list_mapper_primitive(refDemoNested)(&p.nested_list, buffer),"),
+            "{go}"
+        );
+
+        // Common helpers preamble (go1.21+ variant).
+        assert!(go.contains("func newString(s_ref C.StringRef) string {"), "{go}");
+        assert!(go.contains("unsafe.StringData"), "{go}");
+        assert!(go.contains("func ownString(s_ref C.StringRef) string {"), "{go}");
+        assert!(
+            go.contains("func new_list_mapper[T1, T2 any](f func(T1) T2) func(C.ListRef) []T2 {"),
+            "{go}"
+        );
+
+        // go1.18 variant emits the reflect-based string helpers instead.
+        let go118 = raw_file.convert_structs_to_go(&levels, true).unwrap();
+        assert!(
+            go118.contains("func unsafeString(ptr *byte, length int) string {"),
+            "{go118}"
+        );
+        assert!(
+            go118.contains("func unsafeStringData(s string) *byte {"),
+            "{go118}"
+        );
+    }
+
+    #[test]
+    fn ref_struct_generation() {
+        let raw_file = super::RawRsFile::new(DEMO_SRC);
+        let (mapping, ref_structs) = raw_file.convert_structs_to_ref().unwrap();
+
+        // Name mapping: OriginalType -> RefType.
+        assert_eq!(mapping[&ident("String")].to_string(), "StringRef");
+        assert_eq!(mapping[&ident("Vec")].to_string(), "ListRef");
+        assert_eq!(mapping[&ident("DemoNested")].to_string(), "DemoNestedRef");
+        assert_eq!(mapping[&ident("DemoRequest")].to_string(), "DemoRequestRef");
+        assert_eq!(mapping[&ident("DemoResponse")].to_string(), "DemoResponseRef");
+
+        // Generated #[repr(C)] ref structs.
+        let norm = normalize_tokens(ref_structs);
+        assert!(norm.contains("pub struct StringRef {"), "{norm}");
+        assert!(norm.contains("pub struct ListRef {"), "{norm}");
+        assert!(norm.contains("pub struct DemoNestedRef {"), "{norm}");
+        assert!(norm.contains("pub struct DemoRequestRef {"), "{norm}");
+        assert!(norm.contains("pub struct DemoResponseRef {"), "{norm}");
+        assert!(norm.contains("name : StringRef"), "{norm}");
+        assert!(norm.contains("age : u8"), "{norm}");
+        assert!(norm.contains("tags : ListRef"), "{norm}");
+        assert!(norm.contains("scores : ListRef"), "{norm}");
+        assert!(norm.contains("maybe_count : ListRef"), "{norm}");
+        assert!(norm.contains("nested : DemoNestedRef"), "{norm}");
+        assert!(norm.contains("nested_list : ListRef"), "{norm}");
+        assert!(norm.contains("id : u32"), "{norm}");
+        assert!(norm.contains("score : f64"), "{norm}");
+        assert!(norm.contains("pass : bool"), "{norm}");
+    }
+
+    #[test]
+    fn struct_levels() {
+        let raw_file = super::RawRsFile::new(DEMO_SRC);
+        let levels = raw_file.convert_structs_levels().unwrap();
+        // All-primitive struct.
+        assert_eq!(levels.get(&ident("DemoNested")), Some(&0));
+        // Struct with String/Vec<String> fields.
+        assert_eq!(levels.get(&ident("DemoRequest")), Some(&2));
+        // Single bool field.
+        assert_eq!(levels.get(&ident("DemoResponse")), Some(&0));
+        // String is always registered as level 1.
+        assert_eq!(levels.get(&ident("String")), Some(&1));
+    }
+
+    #[test]
+    fn go_struct_tag_generation() {
+        let raw = r#"
+        #[r2g_struct_tag(json = "snake_case")]
+        pub struct TaggedUser {
+            pub user_name: String,
+            pub login_count: u32,
+        }
+        "#;
+        let raw_file = super::RawRsFile::new(raw);
+        let levels = raw_file.convert_structs_levels().unwrap();
+        let go = raw_file.convert_structs_to_go(&levels, false).unwrap();
+        assert!(go.contains("type TaggedUser struct {"), "{go}");
+        assert!(go.contains("user_name string `json:\"user_name\"`"), "{go}");
+        assert!(go.contains("login_count uint32 `json:\"login_count\"`"), "{go}");
+    }
+
+    #[test]
+    fn param_type_conversions() {
+        // Primitive.
+        let pt = param_type("u8");
+        assert!(!pt.is_reference);
+        assert!(matches!(pt.inner, super::ParamTypeInner::Primitive(_)));
+        assert_eq!(pt.to_go(), "uint8");
+        assert_eq!(pt.to_c(false), "uint8_t");
+        assert_eq!(pt.to_c(true), "uint8_t");
+        assert_eq!(pt.to_rust_ref(None).to_string(), "u8");
+
+        // Reference to primitive.
+        let pt = param_type("&i64");
+        assert!(pt.is_reference);
+        assert_eq!(pt.to_go(), "int64");
+        assert_eq!(pt.to_c(false), "int64_t");
+
+        // Other primitives.
+        assert_eq!(param_type("usize").to_go(), "uint");
+        assert_eq!(param_type("usize").to_c(false), "uintptr_t");
+        assert_eq!(param_type("isize").to_go(), "int");
+        assert_eq!(param_type("isize").to_c(false), "intptr_t");
+        assert_eq!(param_type("f32").to_go(), "float32");
+        assert_eq!(param_type("f32").to_c(false), "float");
+        assert_eq!(param_type("f64").to_go(), "float64");
+        assert_eq!(param_type("f64").to_c(false), "double");
+        assert_eq!(param_type("bool").to_go(), "bool");
+        assert_eq!(param_type("bool").to_c(false), "bool");
+        assert_eq!(param_type("char").to_go(), "rune");
+        assert_eq!(param_type("char").to_c(false), "uint32_t");
+
+        // String.
+        let pt = param_type("String");
+        assert!(matches!(pt.inner, super::ParamTypeInner::Custom(_)));
+        assert_eq!(pt.to_go(), "string");
+        assert_eq!(pt.to_c(false), "StringRef");
+        assert_eq!(pt.to_c(true), "struct StringRef");
+        assert_eq!(pt.to_rust_ref(None).to_string(), "StringRef");
+
+        // Custom struct type.
+        let pt = param_type("DemoNested");
+        assert!(matches!(pt.inner, super::ParamTypeInner::Custom(_)));
+        assert_eq!(pt.to_go(), "DemoNested");
+        assert_eq!(pt.to_c(false), "DemoNestedRef");
+        assert_eq!(pt.to_c(true), "struct DemoNestedRef");
+        assert_eq!(pt.to_rust_ref(None).to_string(), "DemoNestedRef");
+
+        // Vec / Option list types.
+        let pt = param_type("Vec<u32>");
+        assert!(matches!(pt.inner, super::ParamTypeInner::List(_)));
+        assert_eq!(pt.to_go(), "[]uint32");
+        assert_eq!(pt.to_c(false), "ListRef");
+        assert_eq!(pt.to_c(true), "struct ListRef");
+        assert_eq!(pt.to_rust_ref(None).to_string(), "ListRef");
+        assert_eq!(param_type("Option<String>").to_go(), "[]string");
+        assert_eq!(param_type("Vec<Vec<u8>>").to_go(), "[][]uint8");
+        assert_eq!(param_type("Option<DemoNested>").to_go(), "[]DemoNested");
+
+        // Associated-type ref form resolves via rust2go::ToRef.
+        let norm = normalize_tokens(param_type("String").to_rust_ref_assoc(None));
+        assert!(norm.contains("rust2go :: ToRef"), "{norm}");
+    }
+
+    #[test]
+    fn param_type_field_converters() {
+        let levels = super::RawRsFile::new("pub struct DemoNested { pub id: u32, }")
+            .convert_structs_levels()
+            .unwrap();
+
+        // Primitive.
+        let pt = param_type("u16");
+        assert_eq!(
+            pt.c_to_go_field_converter(&levels),
+            ("newC_uint16_t".to_string(), 0)
+        );
+        assert_eq!(pt.c_to_go_field_converter_owned(), "newC_uint16_t");
+        assert_eq!(
+            pt.go_to_c_field_counter(&levels),
+            ("cntC_uint16_t".to_string(), 0)
+        );
+        assert_eq!(
+            pt.go_to_c_field_converter(&levels),
+            ("refC_uint16_t".to_string(), 0)
+        );
+
+        // String (level 1 custom).
+        let pt = param_type("String");
+        assert_eq!(
+            pt.c_to_go_field_converter(&levels),
+            ("newString".to_string(), 1)
+        );
+        assert_eq!(pt.c_to_go_field_converter_owned(), "ownString");
+        assert_eq!(
+            pt.go_to_c_field_counter(&levels),
+            ("cntString".to_string(), 1)
+        );
+        assert_eq!(
+            pt.go_to_c_field_converter(&levels),
+            ("refString".to_string(), 1)
+        );
+
+        // Level-0 custom struct.
+        let pt = param_type("DemoNested");
+        assert_eq!(
+            pt.c_to_go_field_converter(&levels),
+            ("newDemoNested".to_string(), 0)
+        );
+        assert_eq!(pt.c_to_go_field_converter_owned(), "ownDemoNested");
+        assert_eq!(
+            pt.go_to_c_field_counter(&levels),
+            ("cntDemoNested".to_string(), 0)
+        );
+        assert_eq!(
+            pt.go_to_c_field_converter(&levels),
+            ("refDemoNested".to_string(), 0)
+        );
+
+        // List of primitives uses the primitive mappers (level 1).
+        let pt = param_type("Vec<u8>");
+        assert_eq!(
+            pt.c_to_go_field_converter(&levels),
+            ("new_list_mapper_primitive(newC_uint8_t)".to_string(), 1)
+        );
+        assert_eq!(
+            pt.c_to_go_field_converter_owned(),
+            "new_list_mapper(newC_uint8_t)"
+        );
+        assert_eq!(
+            pt.go_to_c_field_counter(&levels),
+            ("cnt_list_mapper_primitive(cntC_uint8_t)".to_string(), 1)
+        );
+        assert_eq!(
+            pt.go_to_c_field_converter(&levels),
+            ("ref_list_mapper_primitive(refC_uint8_t)".to_string(), 1)
+        );
+
+        // Option<String> wraps a level-1 type, becoming level 2.
+        let pt = param_type("Option<String>");
+        assert_eq!(
+            pt.c_to_go_field_converter(&levels),
+            ("new_list_mapper(newString)".to_string(), 2)
+        );
+        assert_eq!(pt.c_to_go_field_converter_owned(), "new_list_mapper(ownString)");
+        assert_eq!(
+            pt.go_to_c_field_counter(&levels),
+            ("cnt_list_mapper(cntString)".to_string(), 2)
+        );
+        assert_eq!(
+            pt.go_to_c_field_converter(&levels),
+            ("ref_list_mapper(refString)".to_string(), 2)
+        );
+
+        // List of level-0 structs still uses the primitive mappers (level 1).
+        let pt = param_type("Vec<DemoNested>");
+        assert_eq!(
+            pt.c_to_go_field_converter(&levels),
+            ("new_list_mapper_primitive(newDemoNested)".to_string(), 1)
+        );
+        assert_eq!(
+            pt.go_to_c_field_converter(&levels),
+            ("ref_list_mapper_primitive(refDemoNested)".to_string(), 1)
+        );
+    }
 }

--- a/rust2go-mem-ffi/src/lib.rs
+++ b/rust2go-mem-ffi/src/lib.rs
@@ -190,3 +190,194 @@ pub unsafe fn init_rings<T: 'static + Send>(
 
     Ok((rqueue.read(), wqueue.write()?))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task_desc(buf: &[u8], params_ptr: usize, slot_ptr: usize) -> TaskDesc {
+        TaskDesc {
+            buf: buf.to_vec(),
+            params_ptr,
+            slot_ptr,
+        }
+    }
+
+    #[test]
+    fn payload_new_call() {
+        let p = Payload::new_call(7, 100, 0xdead_beef);
+        assert_eq!(p.ptr, 0xdead_beef);
+        assert_eq!(p.user_data, 100);
+        assert_eq!(p.next_user_data, 0);
+        assert_eq!(p.call_id, 7);
+        assert_eq!(p.flag, 0b0101);
+    }
+
+    #[test]
+    fn payload_new_reply() {
+        let p = Payload::new_reply(3, 10, 20, 0xbeef);
+        assert_eq!(p.ptr, 0xbeef);
+        assert_eq!(p.user_data, 10);
+        assert_eq!(p.next_user_data, 20);
+        assert_eq!(p.call_id, 3);
+        assert_eq!(p.flag, 0b1110);
+    }
+
+    #[test]
+    fn payload_new_drop() {
+        let p = Payload::new_drop(5, 42);
+        assert_eq!(p.ptr, 0);
+        assert_eq!(p.user_data, 42);
+        assert_eq!(p.next_user_data, 0);
+        assert_eq!(p.call_id, 5);
+        assert_eq!(p.flag, 0b1000);
+    }
+
+    #[test]
+    fn payload_new_quit() {
+        let init = Payload::new_quit_init();
+        assert_eq!(init.ptr, 0);
+        assert_eq!(init.user_data, 0);
+        assert_eq!(init.next_user_data, 0);
+        assert_eq!(init.call_id, 0);
+        assert_eq!(init.flag, 0b10100);
+
+        let ack = Payload::new_quit_ack();
+        assert_eq!(ack.ptr, 0);
+        assert_eq!(ack.user_data, 0);
+        assert_eq!(ack.next_user_data, 0);
+        assert_eq!(ack.call_id, 0);
+        assert_eq!(ack.flag, 0b10000);
+    }
+
+    #[test]
+    fn payload_flag_protocol() {
+        let call = Payload::new_call(0, 0, 0).flag;
+        let reply = Payload::new_reply(0, 0, 0, 0).flag;
+        let drop = Payload::new_drop(0, 0).flag;
+        let quit_init = Payload::new_quit_init().flag;
+        let quit_ack = Payload::new_quit_ack().flag;
+
+        // These constants are part of the wire protocol with the Go side
+        // (see go_shm_ring_init codegen: CALL=0b0101, REPLY=0b1110, DROP=0b1000).
+        assert_eq!(call, 0b0101);
+        assert_eq!(reply, 0b1110);
+        assert_eq!(drop, 0b1000);
+        assert_eq!(quit_init, 0b10100);
+        assert_eq!(quit_ack, 0b10000);
+
+        // The dispatcher in init_mem_ffi ignores payloads whose QUIT_ACK bit
+        // is set; QUIT_INIT also carries that bit.
+        assert_eq!(quit_init & quit_ack, quit_ack);
+        assert_ne!(call & quit_ack, quit_ack);
+        assert_ne!(reply & quit_ack, quit_ack);
+        assert_ne!(drop & quit_ack, quit_ack);
+
+        // All five flags must be distinct.
+        let flags = [call, reply, drop, quit_init, quit_ack];
+        for (i, a) in flags.iter().enumerate() {
+            for b in &flags[i + 1..] {
+                assert_ne!(a, b);
+            }
+        }
+    }
+
+    #[test]
+    fn payload_layout_and_copy() {
+        // repr(C): two usize fields followed by two u32 fields, no padding.
+        assert_eq!(
+            std::mem::size_of::<Payload>(),
+            2 * std::mem::size_of::<usize>() + 2 * std::mem::size_of::<u32>()
+        );
+        let p = Payload::new_call(1, 2, 3);
+        let copied = p; // Payload is Copy
+        assert_eq!(copied.ptr, p.ptr);
+        assert_eq!(copied.user_data, p.user_data);
+        assert_eq!(copied.call_id, p.call_id);
+        assert_eq!(copied.flag, p.flag);
+    }
+
+    #[test]
+    fn task_desc_fields_and_handler_signature() {
+        fn handler(ptr: usize, desc: TaskDesc) -> bool {
+            assert_eq!(ptr, 0x10);
+            assert_eq!(desc.buf, b"hello");
+            true
+        }
+        let h: TaskHandler = handler;
+        assert!(h(0x10, task_desc(b"hello", 1, 2)));
+
+        let desc = task_desc(&[1, 2, 3], 0x10, 0x20);
+        assert_eq!(desc.buf, [1, 2, 3]);
+        assert_eq!(desc.params_ptr, 0x10);
+        assert_eq!(desc.slot_ptr, 0x20);
+    }
+
+    #[test]
+    fn slab_push_pop_roundtrip() {
+        let slab: SharedSlab = new_shared_mut(Slab::new());
+        let key1 = push_slab(&slab, task_desc(b"hello", 1, 2));
+        let key2 = push_slab(&slab, task_desc(b"", 3, 4));
+        assert_ne!(key1, key2);
+
+        let d1 = pop_slab(&slab, key1);
+        assert_eq!(d1.buf, b"hello");
+        assert_eq!(d1.params_ptr, 1);
+        assert_eq!(d1.slot_ptr, 2);
+
+        let d2 = pop_slab(&slab, key2);
+        assert!(d2.buf.is_empty());
+        assert_eq!(d2.params_ptr, 3);
+        assert_eq!(d2.slot_ptr, 4);
+    }
+
+    #[test]
+    fn slot_inner_basics() {
+        let mut slot = SlotInner::<u32>::new();
+        assert!(slot.value.is_none());
+        assert!(slot.waker.is_none());
+        slot.set_result(7);
+        assert_eq!(slot.value, Some(7));
+
+        let slot = SlotInner::<u32>::default();
+        assert!(slot.value.is_none());
+        assert!(slot.waker.is_none());
+    }
+
+    #[test]
+    fn new_shared_deref() {
+        let shared = new_shared(5u32);
+        assert_eq!(*shared, 5);
+        let cloned = shared.clone();
+        assert_eq!(*cloned, 5);
+    }
+
+    #[test]
+    fn local_fut_resolves_after_set_result() {
+        use std::future::Future;
+        use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+        fn noop_waker() -> Waker {
+            unsafe fn clone(_: *const ()) -> RawWaker {
+                RawWaker::new(std::ptr::null(), &VTABLE)
+            }
+            unsafe fn wake(_: *const ()) {}
+            unsafe fn wake_by_ref(_: *const ()) {}
+            unsafe fn drop(_: *const ()) {}
+            const VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
+            unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
+        }
+
+        let slot = new_shared_mut(SlotInner::<u32>::new());
+        let fut = LocalFut { slot: slot.clone() };
+        let mut fut = std::pin::pin!(fut);
+
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        // No value yet: pending, and the waker is registered.
+        assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Pending));
+        set_result_for_shared_mut_slot(&slot, 42);
+        assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Ready(42)));
+    }
+}

--- a/rust2go-mem-ffi/src/lib.rs
+++ b/rust2go-mem-ffi/src/lib.rs
@@ -284,10 +284,10 @@ mod tests {
 
     #[test]
     fn payload_layout_and_copy() {
-        // repr(C): two usize fields followed by two u32 fields, no padding.
+        // repr(C): three usize fields followed by two u32 fields, no padding.
         assert_eq!(
             std::mem::size_of::<Payload>(),
-            2 * std::mem::size_of::<usize>() + 2 * std::mem::size_of::<u32>()
+            3 * std::mem::size_of::<usize>() + 2 * std::mem::size_of::<u32>()
         );
         let p = Payload::new_call(1, 2, 3);
         let copied = p; // Payload is Copy


### PR DESCRIPTION
Implements Phase 0 (safety net) of the refactoring plan — items 0.1–0.4 in a single PR:

- **0.1** `rust2go-common`: assertion-based golden tests for the Go emitters and `ParamType` converters (previously `it_works` only printed generated code without assertions)
- **0.2** `rust2go-mem-ffi`: unit tests for Payload constructors / flag protocol constants, TaskDesc, slab helpers, SlotInner, and LocalFut
- **0.3** Go unit tests: `mem-ring` (Slab/LockedSlab/MultiSlab, ring push/pop) and `asmcall` (cgo-based correctness tests for `CallFunc{G0,}P0..P3`, in a standalone `asmcall/calltest` package because cgo in test files breaks dependents built with `-buildmode=c-archive`)
- **0.4** CI: `git diff --exit-code -- '**/gen.go'` after the workspace build so committed generated bindings cannot drift from the .rs sources; also run `go test ./asmcall/... ./mem-ring/...` so the new Go tests execute in CI

Incidental fixes uncovered by the new tests:
- `mem-ring/slab.go`: the freelist used `0` as both the empty sentinel and valid slot index 0, so slot 0 was never reused → use `^uint(0)` as sentinel; `Pop` now clears the stored reference so the GC can reclaim it; added a bounds check
- `mem-ring/queue.go`: the Write drainer goroutine self-deadlocked when `continue` jumped back to `Lock()` while still holding the mutex → unlock before continuing