### PR TITLE
fix: make monoio/tokio features mutually exclusive in mem crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,24 @@ jobs:
         timeout-minutes: 5
         continue-on-error: true
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      # rust2go-mem-ffi and mem-ring reject enabling `monoio` and `tokio`
+      # together (compile_error!), so --all-features is not usable here.
+      # Build with default features (monoio) and cover the tokio branch and
+      # the non-default rust2go/build feature with the steps below.
+      # example-tokio-mem is excluded because feature unification with
+      # example-monoio-mem would enable both runtimes on rust2go-mem-ffi.
       - name: Build
-        run: cargo check --all-features --all-targets
+        run: cargo check --workspace --exclude example-tokio-mem --all-targets
+      - name: Build example-tokio-mem
+        run: cargo check -p example-tokio-mem --all-targets
+      - name: Build rust2go-mem-ffi (tokio)
+        run: cargo check -p rust2go-mem-ffi --no-default-features --features tokio --all-targets
+      - name: Build rust2go (build feature)
+        run: cargo check -p rust2go --features build --all-targets
       - name: Test
-        run: cargo test --workspace --exclude mem-ring --all-features --all-targets
+        run: cargo test --workspace --exclude mem-ring --exclude example-tokio-mem --all-targets
+      - name: Test rust2go-mem-ffi (tokio)
+        run: cargo test -p rust2go-mem-ffi --no-default-features --features tokio --all-targets
       # Test mem-ring separately with the feature set declared by its own
       # Cargo.toml. In a workspace-wide build, feature unification pulls
       # monoio's "sync" feature (required by the `test` crate) into
@@ -41,10 +55,10 @@ jobs:
       # heap on test teardown (glibc "unaligned tcache chunk detected").
       # mem-ring itself does not use monoio/sync.
       - name: Test mem-ring
-        run: cargo test -p mem-ring --all-features --all-targets
-      # --all-features only exercises the monoio branch of mem-ring (the
-      # tokio code is cfg'd out when monoio is enabled), so test the tokio
-      # feature set separately.
+        run: cargo test -p mem-ring --all-targets
+      # Default features only exercise the monoio branch of mem-ring (monoio
+      # and tokio are mutually exclusive), so test the tokio feature set
+      # separately.
       - name: Test mem-ring (tokio)
         run: cargo test -p mem-ring --no-default-features --features tokio --all-targets
       - name: Test Go packages
@@ -74,10 +88,12 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - name: Collect Rust coverage
-        run: cargo llvm-cov --workspace --exclude mem-ring --all-features --all-targets --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --exclude mem-ring --exclude example-tokio-mem --all-targets --lcov --output-path lcov.info
       # See the build-and-test job for why mem-ring is tested separately.
+      # Default features (monoio) are used: monoio and tokio are mutually
+      # exclusive, so --all-features is not usable.
       - name: Collect mem-ring coverage
-        run: cargo llvm-cov -p mem-ring --all-features --all-targets --lcov --output-path lcov-mem-ring.info
+        run: cargo llvm-cov -p mem-ring --all-targets --lcov --output-path lcov-mem-ring.info
       - name: Collect Go coverage
         working-directory: test/go
         run: go test -covermode=atomic -coverprofile=coverage.out ./...
@@ -103,4 +119,9 @@ jobs:
       - name: Install clippy
         run: rustup component add clippy
       - run: cargo fmt --check
-      - run: cargo clippy --all-features --all-targets -- --deny warnings
+      # See the build-and-test job for why --all-features is not usable and
+      # example-tokio-mem is linted separately.
+      - run: cargo clippy --workspace --exclude example-tokio-mem --all-targets -- --deny warnings
+      - run: cargo clippy -p example-tokio-mem --all-targets -- --deny warnings
+      - run: cargo clippy -p rust2go-mem-ffi --no-default-features --features tokio --all-targets -- --deny warnings
+      - run: cargo clippy -p rust2go --features build --all-targets -- --deny warnings

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,38 @@
+# CI Pipeline
+
+The GitHub Actions workflow (`.github/workflows/ci.yml`) runs three jobs on every PR and on pushes to `master`. This document describes what each job covers and the non-obvious constraints behind the current shape.
+
+## Jobs
+
+### build-and-test
+
+- `cargo check` / `cargo test` over the workspace, plus dedicated runs for the feature combinations that a workspace-wide build cannot cover (see "Feature matrix" below).
+- `go test ./asmcall/... ./mem-ring/...` runs the Go unit tests (asmcall correctness tests live in the standalone `asmcall/calltest` package — cgo is not allowed in test files of packages that have no non-test Go files, and cgo test files inside `asmcall` itself would break dependents built with `-buildmode=c-archive`).
+- **Generated-file freshness check**: `git diff --exit-code -- '**/gen.go'` runs after the workspace build. Building the `test` crate and the examples regenerates the committed `gen.go` bindings via their `build.rs` scripts; if the committed copies have drifted from what the `.rs` sources generate, the job fails. When you change anything that affects codegen, regenerate (or hand-update) the committed `gen.go` files — the CI log prints the exact diff if they diverge.
+- The job sets `GODEBUG: invalidptr=0,cgocheck=0`, which the asmcall-based FFI requires; it also masks genuine pointer bugs, so do not rely on it as a safety signal.
+
+### coverage
+
+- `cargo llvm-cov` over the workspace (same feature-matrix exclusions as build-and-test), Go coverage from `test/go`, uploaded to Codecov.
+
+### lint
+
+- `cargo fmt --check` and `cargo clippy ... -- --deny warnings` over the workspace, again with the feature-matrix split below.
+
+## Feature matrix: why there is no `--all-features`
+
+`rust2go-mem-ffi` and `mem-ring` select their async runtime with `all(feature = "tokio", not(feature = "monoio"))` gates, and the `monoio`/`tokio` features are **mutually exclusive** — enabling both is a `compile_error!`, because the combination would silently select the monoio (`Rc<UnsafeCell>`) internals while dependents observe tokio as enabled.
+
+The two `-mem` examples enable opposite runtimes of `rust2go-mem-ffi` (`example-monoio-mem` uses the default monoio, `example-tokio-mem` uses `default-features = false, features = ["tokio"]`). Any workspace-wide cargo invocation would therefore unify the forbidden combination, so:
+
+- Workspace-wide commands exclude `example-tokio-mem` (and use default features elsewhere).
+- `example-tokio-mem` and the tokio branch of `rust2go-mem-ffi` are checked/tested/linted in dedicated steps (`-p ... --no-default-features --features tokio`).
+- `mem-ring` is tested twice: default features (monoio) and `--no-default-features --features tokio`.
+- `rust2go`'s optional `build` feature (bindgen/cbindgen machinery) is checked and linted in its own step.
+
+A side effect of the split: the tokio branches of `rust2go-mem-ffi` are actually compiled in CI now — under `--all-features` they were always cfg'd out.
+
+## Adding new crates or features
+
+- If a new crate introduces mutually exclusive features, add a `compile_error!` guard and extend the matrix above the same way; never reintroduce workspace-wide `--all-features`.
+- If a new crate generates Go bindings committed to git, the freshness check covers it automatically as long as its `build.rs` runs during the workspace build.

--- a/mem-ring/README.md
+++ b/mem-ring/README.md
@@ -8,6 +8,9 @@ With 2 rings, users can simulate calls between rust and go(Both sides can start 
 TODO
 
 ## How to Choose Mode for Rust
+
+The `monoio` (default) and `tokio` features are mutually exclusive: enable exactly one of them. Enabling both fails at compile time, because the runtime branches are selected with `all(feature = "tokio", not(feature = "monoio"))` gates and the combination would otherwise silently pick the monoio internals.
+
 ### For Tokio Users
 ```toml
 [dependencies]

--- a/mem-ring/src/lib.rs
+++ b/mem-ring/src/lib.rs
@@ -1,5 +1,11 @@
 // Copyright 2024 ihciah. All Rights Reserved.
 
+// The runtime branches are selected with `all(feature = "tokio", not(feature = "monoio"))`
+// gates, so enabling both features would silently select the monoio internals
+// while dependents observe tokio as enabled. Reject the combination instead.
+#[cfg(all(feature = "monoio", feature = "tokio"))]
+compile_error!("features `monoio` and `tokio` are mutually exclusive; enable exactly one");
+
 mod eventfd;
 mod queue;
 mod util;

--- a/rust2go-mem-ffi/src/lib.rs
+++ b/rust2go-mem-ffi/src/lib.rs
@@ -1,5 +1,11 @@
 // Copyright 2024 ihciah. All Rights Reserved.
 
+// The runtime branches are selected with `all(feature = "tokio", not(feature = "monoio"))`
+// gates, so enabling both features would silently select the monoio internals
+// while dependents observe tokio as enabled. Reject the combination instead.
+#[cfg(all(feature = "monoio", feature = "tokio"))]
+compile_error!("features `monoio` and `tokio` are mutually exclusive; enable exactly one");
+
 mod future;
 mod utils;
 


### PR DESCRIPTION
Refactor plan item 1.5.

`rust2go-mem-ffi` and `mem-ring` gate runtime-specific code with `all(feature = "tokio", not(feature = "monoio"))`. Enabling both features silently selected the monoio (`Rc<UnsafeCell>`, single-threaded) internals while dependents observed tokio as enabled — a latent unsoundness with no diagnostic. Both crates now emit `compile_error!` for the combination.

CI changes (required, since `--all-features` would now fail):
- Workspace-wide `cargo check/test/clippy/llvm-cov` no longer use `--all-features`. The two `-mem` examples enable opposite runtimes of `rust2go-mem-ffi`, so `example-tokio-mem` is excluded from workspace-wide commands and built/linted separately.
- `mem-ring` default-feature test run replaces the `--all-features` run (same monoio branch that was actually exercised).
- New dedicated steps build/test/lint the tokio branch of `rust2go-mem-ffi` — previously never compiled in CI because feature unification always selected monoio.
- `rust2go`'s optional `build` feature gets its own check/clippy steps.