### PR TITLE
fix: correct the third argument name in CallFunc{G0,}P3 assembly

### DIFF
--- a/asmcall/amd64.s
+++ b/asmcall/amd64.s
@@ -77,7 +77,7 @@ TEXT ·CallFuncG0P3(SB), NOSPLIT|NOPTR|NOFRAME, $0
     MOVQ    fn+0x0(FP), AX
     MOVQ    arg0+0x8(FP), RARG0
     MOVQ    arg1+0x10(FP), RARG1
-    MOVQ    arg1+0x18(FP), RARG2
+    MOVQ    arg2+0x18(FP), RARG2
     G0ASMCALL
 
 TEXT ·CallFuncP0(SB), NOSPLIT|NOPTR|NOFRAME, $0
@@ -103,5 +103,5 @@ TEXT ·CallFuncP3(SB), NOSPLIT|NOPTR|NOFRAME, $0
     MOVQ    fn+0x0(FP), AX
     MOVQ    arg0+0x8(FP), RARG0
     MOVQ    arg1+0x10(FP), RARG1
-    MOVQ    arg1+0x18(FP), RARG2
+    MOVQ    arg2+0x18(FP), RARG2
     ASMCALL

--- a/asmcall/arm64.s
+++ b/asmcall/arm64.s
@@ -53,7 +53,7 @@ TEXT ·CallFuncG0P3(SB), NOSPLIT|NOPTR|NOFRAME, $0
     MOVD    fn+0x0(FP), R8
     MOVD    arg0+0x8(FP), R0
     MOVD    arg1+0x10(FP), R1
-    MOVD    arg1+0x18(FP), R2
+    MOVD    arg2+0x18(FP), R2
     G0ASMCALL
 
 TEXT ·CallFuncP0(SB), NOSPLIT|NOPTR|NOFRAME, $0
@@ -75,5 +75,5 @@ TEXT ·CallFuncP3(SB), NOSPLIT|NOPTR|NOFRAME, $0
     MOVD    fn+0x0(FP), R8
     MOVD    arg0+0x8(FP), R0
     MOVD    arg1+0x10(FP), R1
-    MOVD    arg1+0x18(FP), R2
+    MOVD    arg2+0x18(FP), R2
     ASMCALL


### PR DESCRIPTION
Refactor plan item 1.4.

The P3 entry points in `asmcall/amd64.s` and `asmcall/arm64.s` loaded the 4th parameter as `arg1+0x18(FP)` instead of `arg2+0x18(FP)`. The offset was already correct, so runtime behavior is unchanged — but the wrong operand name trips `go vet`'s asmdecl check and confuses readers.