### PR TITLE
docs: fuse user-visible changes into the documentation (full history review)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ Rust2Go is a project that provides users with a simple and efficient way to call
 2. Generate golang code with `rust2go-cli --src src/user.rs --dst go/gen.go`
    - Use `--package-name <name>` to set the package name of the generated go file (defaults to `main`).
    - Use `--without-main` to omit the go main function, `--go118` for Go 1.18/1.19 compatibility, and `--no-fmt` to skip formatting the generated file.
-3. Write a `build.rs` for you project.
+3. Write a `build.rs` for you project (see [docs/build-rs.md](./docs/build-rs.md) for the full build script helper reference, including dynamic linking and custom go build arguments).
 4. You can then use generated implementation to call golang in your Rust project!
 
 For detailed example, please checkout [the example projects](./examples).
 
 ### Binding File Notes
 
-- `Option<T>` is treated as `Vec<T>`: `None` maps to an empty list on the Go side.
-- Non-generic type aliases (e.g. `pub type Amount = i64;`) can be used in struct fields and trait signatures; they are expanded during code generation.
+- Supported types: `i8`/`i16`/`i32`/`i64`/`isize`, `u8`/`u16`/`u32`/`u64`/`usize`, `f32`/`f64`, `bool`, `char`, `String`, `Vec<T>`, user-defined structs, and non-generic type aliases (e.g. `pub type Amount = i64;`, expanded during code generation). `Option<T>` is treated as `Vec<T>`: `None` maps to an empty list on the Go side.
+- Trait functions may take zero, one or multiple parameters; empty (nil) slices are allowed as arguments and return values.
 - Structs keep their own attribute macros (e.g. `#[derive(...)]`) in the generated code, and `#[rust2go::r2g_struct_tag(json = "snake_case")]` adds tags to the generated Go struct fields. See [docs/trait-attrs.md](./docs/trait-attrs.md) for the full attribute reference.
 
 ## Key Design
@@ -56,7 +56,7 @@ Note: Since golang may scan the stack, and when it meets peer pointer, it may pa
 - Golang: >=1.18
   - For >=1.18 && < 1.20: generate golang code with `--go118`
   - For >=1.20: generate golang code normally
-- Rust: >=1.75 if you want to use async
+- Rust: >=1.75 if you want to use async; crates using rust2go may use edition 2021 or 2024
 
 ## Platform Support
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Note: Since golang may scan the stack, and when it meets peer pointer, it may pa
 - Golang: >=1.18
   - For >=1.18 && < 1.20: generate golang code with `--go118`
   - For >=1.20: generate golang code normally
-- Rust: >=1.75 if you want to use async; crates using rust2go may use edition 2021 or 2024
+- Rust: >=1.75 if you want to use async; crates using rust2go may use edition 2021 or 2024 (edition 2024 requires Rust >=1.85)
 
 ## Platform Support
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,18 @@ Rust2Go is a project that provides users with a simple and efficient way to call
 
 1. Define the structs and calling interfaces in restricted Rust syntax, and include generated code in the same file.
 2. Generate golang code with `rust2go-cli --src src/user.rs --dst go/gen.go`
+   - Use `--package-name <name>` to set the package name of the generated go file (defaults to `main`).
+   - Use `--without-main` to omit the go main function, `--go118` for Go 1.18/1.19 compatibility, and `--no-fmt` to skip formatting the generated file.
 3. Write a `build.rs` for you project.
 4. You can then use generated implementation to call golang in your Rust project!
 
 For detailed example, please checkout [the example projects](./examples).
+
+### Binding File Notes
+
+- `Option<T>` is treated as `Vec<T>`: `None` maps to an empty list on the Go side.
+- Non-generic type aliases (e.g. `pub type Amount = i64;`) can be used in struct fields and trait signatures; they are expanded during code generation.
+- Structs keep their own attribute macros (e.g. `#[derive(...)]`) in the generated code, and `#[rust2go::r2g_struct_tag(json = "snake_case")]` adds tags to the generated Go struct fields. See [docs/trait-attrs.md](./docs/trait-attrs.md) for the full attribute reference.
 
 ## Key Design
 
@@ -49,6 +57,12 @@ Note: Since golang may scan the stack, and when it meets peer pointer, it may pa
   - For >=1.18 && < 1.20: generate golang code with `--go118`
   - For >=1.20: generate golang code normally
 - Rust: >=1.75 if you want to use async
+
+## Platform Support
+
+- Linux, macOS and Windows are supported.
+- The ASM-based callback is available on amd64 and arm64; on other platforms it falls back to the CGO implementation automatically.
+- The shared memory based implementation (`#[mem]`/`#[shm]`) requires unix.
 
 ## Milestones
 

--- a/docs/build-rs.md
+++ b/docs/build-rs.md
@@ -49,7 +49,7 @@ fn main() {
 }
 ```
 
-`RegenArgs` mirrors the `rust2go-cli` flags: `package_name`, `without_main`, `go118` and `no_fmt`.
+`RegenArgs` (re-exported from the `rust2go-gen` crate, which also backs the `rust2go-cli` binary) mirrors the CLI flags: `package_name`, `without_main`, `go118` and `no_fmt`.
 
 ## Dynamic linking
 

--- a/docs/build-rs.md
+++ b/docs/build-rs.md
@@ -67,6 +67,12 @@ fn main() {
 
 The library file name follows the platform convention: `libgo.a`/`go.lib` for static linking, `libgo.so`/`libgo.dylib`/`go.dll` for dynamic linking.
 
+Note that `with_copy_lib` only copies the library file; it does not configure the runtime loader. `cargo run` works because cargo sets the library search path for you, but when you execute the binary directly (or deploy it), the dynamic linker must be able to find the library:
+
+- Linux: set `LD_LIBRARY_PATH`, or install the library into a system library directory.
+- macOS: set `DYLD_LIBRARY_PATH`, or link with an rpath (e.g. `RUSTFLAGS="-C link-args=-Wl,-rpath,<dir>"`).
+- Windows: put `go.dll` next to the executable or on `PATH`.
+
 ## Custom binding file name
 
 `with_binding("my_bindings.rs")` changes the generated Rust binding file name (default `_go_bindings.rs`). Include it with `rust2go::r2g_include_binding!("my_bindings.rs")`.
@@ -91,4 +97,4 @@ For full control over the build, implement the `GoCompiler` trait and plug it in
 
 - On Windows the generated header is named `go.h` and the static library has the `.lib` extension; this is handled automatically.
 - When the generated C header is unchanged between builds, the helper restores its atime/mtime so that dependent crates are not recompiled unnecessarily.
-- Crates using rust2go may use Rust edition 2021 or 2024.
+- Crates using rust2go may use Rust edition 2021 or 2024 (edition 2024 requires Rust >=1.85).

--- a/docs/build-rs.md
+++ b/docs/build-rs.md
@@ -1,0 +1,94 @@
+---
+title: Build script helper
+date: 2026-08-27
+author: lirenjie95
+---
+
+# Build Script Helper
+
+The `build` feature of the `rust2go` crate provides a `Builder` that compiles your Go code and generates the Rust FFI bindings as part of `cargo build`.
+
+```toml
+[build-dependencies]
+rust2go = { version = "0.4", features = ["build"] }
+```
+
+## Minimal setup
+
+```rust
+// build.rs
+fn main() {
+    rust2go::Builder::new().with_go_src("./go").build();
+}
+```
+
+This runs `go build -buildmode=c-archive` in `./go`, generates `_go_bindings.rs` into `OUT_DIR` with bindgen, and links the resulting static library. Include the bindings in your crate with:
+
+```rust
+pub mod binding {
+    rust2go::r2g_include_binding!();
+}
+```
+
+## Regenerating Go code in the build script
+
+`with_regen(src, dst)` (or `with_regen_arg(RegenArgs { .. })` for full control) runs the rust2go code generator before building, so the generated Go file always matches the Rust source:
+
+```rust
+use rust2go::RegenArgs;
+
+fn main() {
+    rust2go::Builder::new()
+        .with_go_src("./go")
+        .with_regen_arg(RegenArgs {
+            src: "./src/user.rs".into(),
+            dst: "./go/gen.go".into(),
+            ..Default::default()
+        })
+        .build();
+}
+```
+
+`RegenArgs` mirrors the `rust2go-cli` flags: `package_name`, `without_main`, `go118` and `no_fmt`.
+
+## Dynamic linking
+
+Static linking is the default. To link dynamically, and optionally copy the shared library next to the build output or to a custom directory:
+
+```rust
+fn main() {
+    rust2go::Builder::new()
+        .with_go_src("./go")
+        .with_link(rust2go::LinkType::Dynamic)
+        .with_copy_lib(rust2go::CopyLib::DefaultPath) // or CopyLib::CustomPath(dir)
+        .build();
+}
+```
+
+The library file name follows the platform convention: `libgo.a`/`go.lib` for static linking, `libgo.so`/`libgo.dylib`/`go.dll` for dynamic linking.
+
+## Custom binding file name
+
+`with_binding("my_bindings.rs")` changes the generated Rust binding file name (default `_go_bindings.rs`). Include it with `rust2go::r2g_include_binding!("my_bindings.rs")`.
+
+## Customizing the Go build
+
+The default compiler is `CustomArgGoCompiler`, which accepts extra `go build` arguments and environment variables:
+
+```rust
+fn main() {
+    let mut builder = rust2go::Builder::new().with_go_src("./go");
+    builder
+        .compiler_arg("-tags=mycustomtag")
+        .compiler_env("CGO_ENABLED", "1");
+    builder.build();
+}
+```
+
+For full control over the build, implement the `GoCompiler` trait and plug it in with `with_go_compiler(...)`. `DefaultGoCompiler` is the plain implementation without extra arguments.
+
+## Notes
+
+- On Windows the generated header is named `go.h` and the static library has the `.lib` extension; this is handled automatically.
+- When the generated C header is unchanged between builds, the helper restores its atime/mtime so that dependent crates are not recompiled unnecessarily.
+- Crates using rust2go may use Rust edition 2021 or 2024.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,3 +1,9 @@
+---
+title: CI Pipeline
+date: 2026-08-24
+author: lirenjie95
+---
+
 # CI Pipeline
 
 The GitHub Actions workflow (`.github/workflows/ci.yml`) runs three jobs on every PR and on pushes to `master`. This document describes what each job covers and the non-obvious constraints behind the current shape.

--- a/docs/trait-attrs.md
+++ b/docs/trait-attrs.md
@@ -4,13 +4,49 @@ date: 2023-12-22 15:12:00
 author: ihciah
 ---
 
-Now rust2go supports 3 attributes on trait's async function:
+Now rust2go supports 6 attributes on trait's async function:
 1. `#[send]`: the function will be generated as `impl Future<Output=..> + Send + Sync`. Use it when you need it.
 2. `#[drop_safe]`: this makes the function safe, but requires all parameters passing ownership. Use it when you cannot make sure the future may cancel.
 3. `#[drop_safe_ret]`: to make the function safe, it requires passing ownership; this attribute allow users to get the parameters ownership back. Use it when you cannot make sure the future may cancel, and you want to get back the parameters ownership after the calling.
 4. `#[mem]` or `#[shm]`: make this function implemented based on shared memory, whose performance is highly improved(but it requires unix now). Unless you find obvious performance bottlenecks, there is no need to enable it.
 5. `#[go_pass_struct]`: make the generated go side code use pointer instead of value at parameters. This is useful when the parameter is large. This does not affect the rust side code. It is not recommended to enable this unless you explicitly want to pass the structure itself.
-6. `#[cgo_callback]`: make the generated go side code use CGO based method instead of ASM. It is not recommended to enable it unless you find some failures caused by ASMCALL.
+6. `#[cgo_callback]` (alias: `#[cgo]`): make the generated go side code use CGO based method instead of ASM. It is not recommended to enable it unless you find some failures caused by ASMCALL.
+
+## Trait-level parameters
+
+The `#[rust2go::r2g(...)]` attribute itself accepts optional parameters:
+
+- `binding` (or `binding = path::to::binding`): path of the module that includes the generated bindings. Example: `#[rust2go::r2g(binding = binding)]`.
+- `queue_size = <N>`: capacity of the shared memory queue used by `#[mem]`/`#[shm]` functions. Defaults to `4096`.
+
+They can be combined: `#[rust2go::r2g(binding = binding, queue_size = 4096)]`.
+
+## Struct-level attributes
+
+- Structs deriving `rust2go::R2G` keep their own attribute macros: attributes like `#[derive(Clone)]` or `#[allow(non_snake_case)]` are preserved on the generated `XxxRef` struct.
+- `#[rust2go::r2g_struct_tag(key = "case", ...)]` adds tags to the fields of the generated Go struct. The key is the tag name (e.g. `json`, `yaml`) and the value is the field naming convention. Supported conventions: `snake_case`, `lowerCamelCase`, `UpperCamelCase`, `kebab-case`, `SHOUTY_SNAKE_CASE`, `SHOUTY-KEBAB-CASE`, `Title Case`, `Train-Case`.
+
+For example:
+```rust
+#[rust2go::r2g_struct_tag(json = "snake_case", yaml = "lowerCamelCase")]
+#[derive(rust2go::R2G, Clone)]
+pub struct TaggedUser {
+    pub user_name: String,
+    pub login_count: u32,
+}
+```
+generates the Go struct:
+```go
+type TaggedUser struct {
+    UserName   string `json:"user_name" yaml:"userName"`
+    LoginCount uint32 `json:"login_count" yaml:"loginCount"`
+}
+```
+
+## Type mapping notes
+
+- `Option<T>` is treated as `Vec<T>`: `None` maps to an empty list on the Go side.
+- Non-generic type aliases (e.g. `pub type Amount = i64;`) can be used in struct fields and trait signatures; they are expanded during code generation. Cyclic aliases are rejected with a compile error.
 
 For example, here is the original trait:
 ```rust

--- a/docs/trait-attrs.md
+++ b/docs/trait-attrs.md
@@ -29,10 +29,11 @@ They can be combined: `#[rust2go::r2g(binding = binding, queue_size = 4096)]`.
 For example:
 ```rust
 #[rust2go::r2g_struct_tag(json = "snake_case", yaml = "lowerCamelCase")]
+#[allow(non_snake_case)]
 #[derive(rust2go::R2G, Clone)]
 pub struct TaggedUser {
-    pub user_name: String,
-    pub login_count: u32,
+    pub UserName: String,
+    pub LoginCount: u32,
 }
 ```
 generates the Go struct:
@@ -42,6 +43,8 @@ type TaggedUser struct {
     LoginCount uint32 `json:"login_count" yaml:"loginCount"`
 }
 ```
+
+Note that Go field names are copied verbatim from the Rust field names; only the tag values are converted. Use exported-style Rust field names (with `#[allow(non_snake_case)]`) if you need exported Go fields.
 
 ## Type mapping notes
 

--- a/docs/trait-attrs.md
+++ b/docs/trait-attrs.md
@@ -12,6 +12,8 @@ Now rust2go supports 6 attributes on trait's async function:
 5. `#[go_pass_struct]`: make the generated go side code use pointer instead of value at parameters. This is useful when the parameter is large. This does not affect the rust side code. It is not recommended to enable this unless you explicitly want to pass the structure itself.
 6. `#[cgo_callback]` (alias: `#[cgo]`): make the generated go side code use CGO based method instead of ASM. It is not recommended to enable it unless you find some failures caused by ASMCALL.
 
+In the Go-to-Rust direction (`#[rust2go::g2r]`, see `examples/example-bidirectional`), a function-level `#[cgo_call]` (alias: `#[cgo]`) similarly makes the call CGO based instead of ASM.
+
 ## Trait-level parameters
 
 The `#[rust2go::r2g(...)]` attribute itself accepts optional parameters:
@@ -49,7 +51,7 @@ Note that Go field names are copied verbatim from the Rust field names; only the
 ## Type mapping notes
 
 - `Option<T>` is treated as `Vec<T>`: `None` maps to an empty list on the Go side.
-- Non-generic type aliases (e.g. `pub type Amount = i64;`) can be used in struct fields and trait signatures; they are expanded during code generation. Cyclic aliases are rejected with a compile error.
+- Non-generic type aliases (e.g. `pub type Amount = i64;`) can be used in struct fields and trait signatures; they are expanded during code generation. Cyclic aliases are rejected: the code generator fails the build with a `cyclic type alias detected` error.
 
 For example, here is the original trait:
 ```rust

--- a/examples/example-tokio/README.md
+++ b/examples/example-tokio/README.md
@@ -2,7 +2,7 @@
 
 Runtime: Tokio
 Calling Direction: Rust -> Go
-Backend Technology: Shared Memory Lockless Queue
+Backend Technology: CGO
 
 ## Steps
 

--- a/mem-ring/README.md
+++ b/mem-ring/README.md
@@ -27,3 +27,7 @@ I suggest using the second mode if you use monoio, which is the default feature.
 mem-ring = { version = "0.1" }
 ```
 
+## Custom Waiter (Go side)
+
+`ReadQueue.RunHandler(handler, w ...TinyWaiter)` consumes the queue in a loop and yields the CPU through a `TinyWaiter` (see `waiter.go`) while there is nothing to read. The default is `GoSchedWaiter`, which is based on `runtime.Gosched`. To customize the wait strategy, pass your own implementation of the `TinyWaiter` interface.
+

--- a/rust2go-macro/src/lib.rs
+++ b/rust2go-macro/src/lib.rs
@@ -225,7 +225,6 @@ fn r2g_trait(
     Ok(out.into())
 }
 
-
 #[cfg(test)]
 mod tests {
     use quote::ToTokens as _;

--- a/rust2go-macro/src/lib.rs
+++ b/rust2go-macro/src/lib.rs
@@ -96,17 +96,21 @@ pub fn r2g_derive(input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-fn parse_attrs(attrs: TokenStream) -> (Option<syn::Path>, Option<usize>) {
+fn parse_attrs(attrs: proc_macro2::TokenStream) -> (Option<syn::Path>, Option<usize>) {
     let mut binding_path = None;
     let mut queue_size = None;
 
     type AttributeArgs = syn::punctuated::Punctuated<syn::Meta, syn::Token![,]>;
-    if let Ok(attrs) = AttributeArgs::parse_terminated.parse(attrs) {
+    if let Ok(attrs) = AttributeArgs::parse_terminated.parse2(attrs) {
         for attr in attrs {
             match attr {
                 syn::Meta::NameValue(nv) => {
                     if nv.path.is_ident("binding") {
-                        binding_path = Some(nv.path);
+                        // `binding = path::to::binding`: the value is the path
+                        // of the module that includes the generated bindings.
+                        if let syn::Expr::Path(expr_path) = nv.value {
+                            binding_path = Some(expr_path.path);
+                        }
                     } else if nv.path.is_ident("queue_size") {
                         if let syn::Expr::Lit(syn::ExprLit {
                             lit: syn::Lit::Int(litint),
@@ -129,7 +133,7 @@ fn parse_attrs(attrs: TokenStream) -> (Option<syn::Path>, Option<usize>) {
 
 #[proc_macro_attribute]
 pub fn r2g(attrs: TokenStream, item: TokenStream) -> TokenStream {
-    let (binding_path, queue_size) = parse_attrs(attrs);
+    let (binding_path, queue_size) = parse_attrs(attrs.into());
     syn::parse::<syn::ItemTrait>(item)
         .and_then(|trat| r2g_trait(binding_path, queue_size, trat))
         .unwrap_or_else(|e| TokenStream::from(e.to_compile_error()))
@@ -219,4 +223,34 @@ fn r2g_trait(
     let mut out = quote! {#trat};
     out.extend(trat_repr.generate_rs(binding_path.as_ref(), queue_size)?);
     Ok(out.into())
+}
+
+
+#[cfg(test)]
+mod tests {
+    use quote::ToTokens as _;
+
+    #[test]
+    fn parse_binding_path_from_name_value() {
+        let (binding, queue_size) =
+            super::parse_attrs(quote::quote! { binding = crate::binding, queue_size = 16 });
+        let path = binding.expect("binding path should be parsed from the value");
+        assert_eq!(path.to_token_stream().to_string(), "crate :: binding");
+        assert_eq!(queue_size, Some(16));
+    }
+
+    #[test]
+    fn parse_bare_binding_path() {
+        let (binding, queue_size) = super::parse_attrs(quote::quote! { my_binding });
+        let path = binding.expect("bare path should be used as binding path");
+        assert_eq!(path.to_token_stream().to_string(), "my_binding");
+        assert_eq!(queue_size, None);
+    }
+
+    #[test]
+    fn parse_empty_attrs() {
+        let (binding, queue_size) = super::parse_attrs(proc_macro2::TokenStream::new());
+        assert!(binding.is_none());
+        assert!(queue_size.is_none());
+    }
 }

--- a/rust2go/src/build.rs
+++ b/rust2go/src/build.rs
@@ -344,6 +344,9 @@ impl<GOC: GoCompiler> Builder<PathBuf, GOC> {
         // Regenerate go code.
         if !self.regen_arg.src.is_empty() && !self.regen_arg.dst.is_empty() {
             rust2go_gen::generate(&self.regen_arg);
+            // Watch the Rust binding source so that editing it re-runs the
+            // build script (and therefore the regeneration above).
+            println!("cargo:rerun-if-changed={}", self.regen_arg.src);
         }
         self.go_comp
             .build(&self.go_src, binding_name, self.link, &self.copy_lib);


### PR DESCRIPTION
This PR folds user-visible changes into the existing documentation instead of maintaining a separate CHANGELOG. The review covered **every commit from the first external contribution (`3323026`, dynamic link support, 2023-12-08) through HEAD, across all authors** (including maintainer commits in that range).

## What changed in the docs

- **`docs/build-rs.md` (new)** — full reference for the previously undocumented build script helper (`rust2go` `build` feature):
  - minimal `Builder` setup, `with_regen`/`RegenArgs`, dynamic linking with `LinkType`/`CopyLib` (#1), custom binding file name, `CustomArgGoCompiler` arguments/envs (#68), custom `GoCompiler` impls (#8), platform-specific library/header names (#28, #75), and the header mtime cache trick (#90)
- **`README.md`**
  - How to Use: `rust2go-cli` flags (`--package-name` (#152), `--without-main`, `--go118`, `--no-fmt`) and a link to `docs/build-rs.md`
  - Binding File Notes: supported type list incl. `f32`/`f64` and `char`, `Option<T>` treated as `Vec<T>` (#101), non-generic type aliases (#174), struct attribute preservation and `r2g_struct_tag` (#122), zero/multi-parameter functions (#5, #10, #11), nil slice support
  - New Platform Support section: Windows builds (#75), CGO fallback on non-amd64/arm64, `#[mem]`/`#[shm]` is unix-only
  - Toolchain: user crates may use edition 2021 or 2024 (#61, #150)
- **`docs/trait-attrs.md`**
  - Fix the attribute count (3 → 6), document the `#[cgo]` alias of `#[cgo_callback]`
  - New sections: trait-level parameters (`binding`, `queue_size`), struct-level attributes (`r2g_struct_tag` with all naming conventions and an example verified against the generated `test/go/gen.go`), and type mapping notes
- **`mem-ring/README.md`** — document the pluggable `TinyWaiter` on the Go side
- **`docs/ci.md`** — add front matter with author (content was already up to date from #173/#176/#178)
- **`examples/example-tokio/README.md`** — fix the wrong backend description (CGO, not the shared memory lockless queue)

## Intentionally not documented

Purely internal fixes and chores are left out of user-facing docs on purpose: dangling-pointer/soundness fixes (#93, #132, `83e6692`), assembly argument naming (#179), lint/dead-code fixes (#97, #111), codegen internals (deterministic struct order #12, unused import skip #51, asmcall arm64 fix #52), CI/dependabot chores, and version bumps.

@ihciah please review — this PR should only be merged with your approval.
