### PR TITLE
refactor: single primitive table and shared ref-field classification (task 2.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,6 +799,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
+ "rust2go-convert",
  "syn",
 ]
 

--- a/rust2go-common/Cargo.toml
+++ b/rust2go-common/Cargo.toml
@@ -12,6 +12,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+rust2go-convert = { version = "0.1.1", path = "../rust2go-convert" }
+
 syn = { version = "2", features = ["full"] }
 quote = { version = "1" }
 proc-macro2 = { version = "1" }

--- a/rust2go-common/src/common.rs
+++ b/rust2go-common/src/common.rs
@@ -7,6 +7,7 @@ use heck::{
 };
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote, ToTokens};
+use rust2go_convert::primitive_by_rust_ident;
 use std::collections::HashMap;
 use syn::parse::Parser;
 use syn::{
@@ -549,8 +550,8 @@ typedef struct QueueMeta {
         }
         fn type_to_node(ty: &Type) -> Result<Node> {
             let seg = type_to_segment(ty)?;
-            match seg.ident.to_string().as_str() {
-                "Vec" | "Option" => {
+            match classify_ref_field(&seg.ident) {
+                RefFieldClass::List => {
                     let inside = match &seg.arguments {
                         syn::PathArguments::AngleBracketed(ga) => match ga.args.last().unwrap() {
                             syn::GenericArgument::Type(ty) => ty,
@@ -560,8 +561,7 @@ typedef struct QueueMeta {
                     };
                     Ok(Node::List(Box::new(type_to_node(inside)?)))
                 }
-                "u8" | "u16" | "u32" | "u64" | "usize" | "i8" | "i16" | "i32" | "i64" | "isize"
-                | "bool" | "char" | "f32" | "f64" => Ok(Node::Primitive),
+                RefFieldClass::Primitive => Ok(Node::Primitive),
                 _ => Ok(Node::NamedStruct(seg.ident.clone())),
             }
         }
@@ -736,6 +736,43 @@ impl ToTokens for ParamType {
     }
 }
 
+/// Classification of a type for ref-struct field generation. Shared by the
+/// CLI codegen (`convert_structs_to_ref`) and the `R2G` derive macro so both
+/// paths apply the exact same rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefFieldClass {
+    /// Primitives are kept as-is in the ref struct.
+    Primitive,
+    /// `String` maps to `StringRef`.
+    String,
+    /// `Vec<T>` and `Option<T>` map to `ListRef`.
+    List,
+    /// Any other type is a custom (struct) type.
+    Custom,
+}
+
+/// Classify a type by its (first) path segment ident.
+pub fn classify_ref_field(ident: &Ident) -> RefFieldClass {
+    match ident.to_string().as_str() {
+        "Vec" | "Option" => RefFieldClass::List,
+        "String" => RefFieldClass::String,
+        name if primitive_by_rust_ident(name).is_some() => RefFieldClass::Primitive,
+        _ => RefFieldClass::Custom,
+    }
+}
+
+// Go converter function name for a primitive type: the prefix (`newC_`,
+// `cntC_` or `refC_`) followed by its C type name, e.g. `newC_uint8_t`.
+// Returns None for unknown primitives and for primitives without generated
+// converters (currently `char`).
+fn go_primitive_converter(name: &Ident, prefix: &str) -> Option<String> {
+    let info = primitive_by_rust_ident(&name.to_string())?;
+    if !info.has_go_converters {
+        return None;
+    }
+    Some(format!("{prefix}{}", info.c_name))
+}
+
 impl TryFrom<&Type> for ParamType {
     type Error = Error;
 
@@ -748,15 +785,14 @@ impl TryFrom<&Type> for ParamType {
 
         // TypePath -> ParamType
         let seg = type_to_segment(ty)?;
-        let param_type_inner = match seg.ident.to_string().as_str() {
-            "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "usize" | "isize"
-            | "bool" | "char" | "f32" | "f64" => {
+        let param_type_inner = match classify_ref_field(&seg.ident) {
+            RefFieldClass::Primitive => {
                 if !seg.arguments.is_none() {
                     sbail!("primitive types with arguments are not supported")
                 }
                 ParamTypeInner::Primitive(seg.ident.clone())
             }
-            "Vec" | "Option" => ParamTypeInner::List(ty.clone()),
+            RefFieldClass::List => ParamTypeInner::List(ty.clone()),
             _ => {
                 if !seg.arguments.is_none() {
                     sbail!("custom types with arguments are not supported")
@@ -775,24 +811,10 @@ impl ParamType {
     pub fn to_c(&self, with_struct: bool) -> String {
         let struct_ = if with_struct { "struct " } else { "" };
         match &self.inner {
-            ParamTypeInner::Primitive(name) => match name.to_string().as_str() {
-                "u8" => "uint8_t",
-                "u16" => "uint16_t",
-                "u32" => "uint32_t",
-                "u64" => "uint64_t",
-                "i8" => "int8_t",
-                "i16" => "int16_t",
-                "i32" => "int32_t",
-                "i64" => "int64_t",
-                "bool" => "bool",
-                "char" => "uint32_t",
-                "usize" => "uintptr_t",
-                "isize" => "intptr_t",
-                "f32" => "float",
-                "f64" => "double",
-                _ => panic!("unreconigzed rust primitive type {name}"),
-            }
-            .to_string(),
+            ParamTypeInner::Primitive(name) => match primitive_by_rust_ident(&name.to_string()) {
+                Some(info) => info.c_name.to_string(),
+                None => panic!("unreconigzed rust primitive type {name}"),
+            },
             ParamTypeInner::Custom(c) => format!("{struct_}{c}Ref"),
             ParamTypeInner::List(_) => format!("{struct_}ListRef"),
         }
@@ -800,24 +822,10 @@ impl ParamType {
 
     pub fn to_go(&self) -> String {
         match &self.inner {
-            ParamTypeInner::Primitive(name) => match name.to_string().as_str() {
-                "u8" => "uint8",
-                "u16" => "uint16",
-                "u32" => "uint32",
-                "u64" => "uint64",
-                "i8" => "int8",
-                "i16" => "int16",
-                "i32" => "int32",
-                "i64" => "int64",
-                "bool" => "bool",
-                "char" => "rune",
-                "usize" => "uint",
-                "isize" => "int",
-                "f32" => "float32",
-                "f64" => "float64",
-                _ => panic!("unreconigzed rust primitive type {name}"),
-            }
-            .to_string(),
+            ParamTypeInner::Primitive(name) => match primitive_by_rust_ident(&name.to_string()) {
+                Some(info) => info.go_name.to_string(),
+                None => panic!("unreconigzed rust primitive type {name}"),
+            },
             ParamTypeInner::Custom(c) => {
                 let s = c.to_string();
                 match s.as_str() {
@@ -848,23 +856,8 @@ impl ParamType {
     pub fn c_to_go_field_converter(&self, mapping: &HashMap<Ident, u8>) -> (String, u8) {
         match &self.inner {
             ParamTypeInner::Primitive(name) => (
-                match name.to_string().as_str() {
-                    "u8" => "newC_uint8_t",
-                    "u16" => "newC_uint16_t",
-                    "u32" => "newC_uint32_t",
-                    "u64" => "newC_uint64_t",
-                    "i8" => "newC_int8_t",
-                    "i16" => "newC_int16_t",
-                    "i32" => "newC_int32_t",
-                    "i64" => "newC_int64_t",
-                    "bool" => "newC_bool",
-                    "usize" => "newC_uintptr_t",
-                    "isize" => "newC_intptr_t",
-                    "f32" => "newC_float",
-                    "f64" => "newC_double",
-                    _ => panic!("unrecognized rust primitive type {name}"),
-                }
-                .to_string(),
+                go_primitive_converter(name, "newC_")
+                    .unwrap_or_else(|| panic!("unrecognized rust primitive type {name}")),
                 0,
             ),
             ParamTypeInner::Custom(c) => (
@@ -895,23 +888,8 @@ impl ParamType {
     // f: StructRef -> Struct with fully ownership
     pub fn c_to_go_field_converter_owned(&self) -> String {
         match &self.inner {
-            ParamTypeInner::Primitive(name) => match name.to_string().as_str() {
-                "u8" => "newC_uint8_t",
-                "u16" => "newC_uint16_t",
-                "u32" => "newC_uint32_t",
-                "u64" => "newC_uint64_t",
-                "i8" => "newC_int8_t",
-                "i16" => "newC_int16_t",
-                "i32" => "newC_int32_t",
-                "i64" => "newC_int64_t",
-                "bool" => "newC_bool",
-                "usize" => "newC_uintptr_t",
-                "isize" => "newC_intptr_t",
-                "f32" => "newC_float",
-                "f64" => "newC_double",
-                _ => panic!("unrecognized rust primitive type {name}"),
-            }
-            .to_string(),
+            ParamTypeInner::Primitive(name) => go_primitive_converter(name, "newC_")
+                .unwrap_or_else(|| panic!("unrecognized rust primitive type {name}")),
             ParamTypeInner::Custom(c) => format!("own{}", c.to_string().as_str()),
             ParamTypeInner::List(inner) => {
                 let seg = type_to_segment(inner).unwrap();
@@ -933,23 +911,8 @@ impl ParamType {
     pub fn go_to_c_field_counter(&self, mapping: &HashMap<Ident, u8>) -> (String, u8) {
         match &self.inner {
             ParamTypeInner::Primitive(name) => (
-                match name.to_string().as_str() {
-                    "u8" => "cntC_uint8_t",
-                    "u16" => "cntC_uint16_t",
-                    "u32" => "cntC_uint32_t",
-                    "u64" => "cntC_uint64_t",
-                    "i8" => "cntC_int8_t",
-                    "i16" => "cntC_int16_t",
-                    "i32" => "cntC_int32_t",
-                    "i64" => "cntC_int64_t",
-                    "bool" => "cntC_bool",
-                    "usize" => "cntC_uintptr_t",
-                    "isize" => "cntC_intptr_t",
-                    "f32" => "cntC_float",
-                    "f64" => "cntC_double",
-                    _ => panic!("unrecognized rust primitive type {name}"),
-                }
-                .to_string(),
+                go_primitive_converter(name, "cntC_")
+                    .unwrap_or_else(|| panic!("unrecognized rust primitive type {name}")),
                 0,
             ),
             ParamTypeInner::Custom(c) => (
@@ -981,23 +944,8 @@ impl ParamType {
     pub fn go_to_c_field_converter(&self, mapping: &HashMap<Ident, u8>) -> (String, u8) {
         match &self.inner {
             ParamTypeInner::Primitive(name) => (
-                match name.to_string().as_str() {
-                    "u8" => "refC_uint8_t",
-                    "u16" => "refC_uint16_t",
-                    "u32" => "refC_uint32_t",
-                    "u64" => "refC_uint64_t",
-                    "i8" => "refC_int8_t",
-                    "i16" => "refC_int16_t",
-                    "i32" => "refC_int32_t",
-                    "i64" => "refC_int64_t",
-                    "bool" => "refC_bool",
-                    "usize" => "refC_uintptr_t",
-                    "isize" => "refC_intptr_t",
-                    "f32" => "refC_float",
-                    "f64" => "refC_double",
-                    _ => panic!("unreconigzed rust primitive type {name}"),
-                }
-                .to_string(),
+                go_primitive_converter(name, "refC_")
+                    .unwrap_or_else(|| panic!("unreconigzed rust primitive type {name}")),
                 0,
             ),
             ParamTypeInner::Custom(c) => (

--- a/rust2go-convert/src/convert.rs
+++ b/rust2go-convert/src/convert.rs
@@ -249,7 +249,7 @@ impl FromRef for String {
 }
 
 macro_rules! primitive_impl {
-    ($($ty:ty),*) => {
+    ($(($ty:ty, $c:literal, $go:literal, $conv:literal)),*) => {
         $(
             impl ToRef for $ty {
                 const MEM_TYPE: MemType = MemType::Primitive;
@@ -275,7 +275,9 @@ macro_rules! primitive_impl {
     };
 }
 
-primitive_impl!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64, bool, char);
+// The impl list comes from the shared primitive table definition, so the
+// impls and the table always cover the same set of types.
+with_primitives!(primitive_impl);
 
 macro_rules! tuple_impl {
     (($ty:ident, $name:tt)) => {

--- a/rust2go-convert/src/lib.rs
+++ b/rust2go-convert/src/lib.rs
@@ -3,5 +3,8 @@
 #![recursion_limit = "4096"]
 
 #[macro_use]
+mod primitive;
+#[macro_use]
 mod convert;
 pub use convert::*;
+pub use primitive::*;

--- a/rust2go-convert/src/primitive.rs
+++ b/rust2go-convert/src/primitive.rs
@@ -1,0 +1,105 @@
+// Copyright 2024 ihciah. All Rights Reserved.
+
+/// Mapping between a Rust primitive type and its C / Go counterparts.
+#[derive(Debug)]
+pub struct PrimitiveInfo {
+    /// Rust type name, e.g. `u8`.
+    pub rust_ident: &'static str,
+    /// C type name, e.g. `uint8_t`.
+    pub c_name: &'static str,
+    /// Go type name, e.g. `uint8`.
+    pub go_name: &'static str,
+    /// Whether Go field converters (`newC_*` / `cntC_*` / `refC_*`) are
+    /// generated for this type. `char` maps to `uint32_t` on the C side but
+    /// has no converters of its own.
+    pub has_go_converters: bool,
+}
+
+// The single list of all supported primitives. It drives both the PRIMITIVES
+// table below and the ToRef/FromRef impls in convert.rs, so they cannot
+// drift apart. The codegen crates (rust2go-common, and rust2go-macro through
+// it) read the table as their own source of truth.
+macro_rules! with_primitives {
+    ($cb:ident) => {
+        $cb!(
+            (u8, "uint8_t", "uint", true),
+            (u16, "uint16_t", "uint16", true),
+            (u32, "uint32_t", "uint32", true),
+            (u64, "uint64_t", "uint64", true),
+            (usize, "uintptr_t", "uint", true),
+            (i8, "int8_t", "int8", true),
+            (i16, "int16_t", "int16", true),
+            (i32, "int32_t", "int32", true),
+            (i64, "int64_t", "int64", true),
+            (isize, "intptr_t", "int", true),
+            (f32, "float", "float32", true),
+            (f64, "double", "float64", true),
+            (bool, "bool", "bool", true),
+            (char, "uint32_t", "rune", false)
+        );
+    };
+}
+
+macro_rules! primitives_table {
+    ($(($rust:ident, $c:literal, $go:literal, $conv:literal)),*) => {
+        /// All supported primitive types.
+        pub static PRIMITIVES: &[PrimitiveInfo] = &[$(
+            PrimitiveInfo {
+                rust_ident: stringify!($rust),
+                c_name: $c,
+                go_name: $go,
+                has_go_converters: $conv,
+            }
+        ),*];
+    };
+}
+
+with_primitives!(primitives_table);
+
+/// Look up a primitive by its Rust type name.
+pub fn primitive_by_rust_ident(name: &str) -> Option<&'static PrimitiveInfo> {
+    PRIMITIVES.iter().find(|p| p.rust_ident == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_lookup() {
+        let info = primitive_by_rust_ident("u8").unwrap();
+        assert_eq!(info.c_name, "uint8_t");
+        assert_eq!(info.go_name, "uint8");
+        assert!(info.has_go_converters);
+
+        let info = primitive_by_rust_ident("f64").unwrap();
+        assert_eq!(info.c_name, "double");
+        assert_eq!(info.go_name, "float64");
+
+        // char has C/Go names but no generated Go converters.
+        let info = primitive_by_rust_ident("char").unwrap();
+        assert_eq!(info.c_name, "uint32_t");
+        assert_eq!(info.go_name, "rune");
+        assert!(!info.has_go_converters);
+
+        assert!(primitive_by_rust_ident("String").is_none());
+        assert_eq!(PRIMITIVES.len(), 14);
+    }
+
+    #[test]
+    fn rust_idents_match_type_names() {
+        // The table is built with stringify!; make sure the idents match the
+        // real type names so lookups by actual types keep working.
+        macro_rules! case {
+            ($($ty:ty),*) => { $({
+                assert_eq!(
+                    primitive_by_rust_ident(std::any::type_name::<$ty>())
+                        .unwrap()
+                        .rust_ident,
+                    std::any::type_name::<$ty>()
+                );
+            })* };
+        }
+        case!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64, bool, char);
+    }
+}

--- a/rust2go-convert/src/primitive.rs
+++ b/rust2go-convert/src/primitive.rs
@@ -22,7 +22,7 @@ pub struct PrimitiveInfo {
 macro_rules! with_primitives {
     ($cb:ident) => {
         $cb!(
-            (u8, "uint8_t", "uint", true),
+            (u8, "uint8_t", "uint8", true),
             (u16, "uint16_t", "uint16", true),
             (u32, "uint32_t", "uint32", true),
             (u64, "uint64_t", "uint64", true),
@@ -84,6 +84,34 @@ mod tests {
 
         assert!(primitive_by_rust_ident("String").is_none());
         assert_eq!(PRIMITIVES.len(), 14);
+    }
+
+    #[test]
+    fn table_matches_expected_mappings() {
+        // Full mapping cross-check: (rust, c, go, has_go_converters).
+        let expected: &[(&str, &str, &str, bool)] = &[
+            ("u8", "uint8_t", "uint8", true),
+            ("u16", "uint16_t", "uint16", true),
+            ("u32", "uint32_t", "uint32", true),
+            ("u64", "uint64_t", "uint64", true),
+            ("usize", "uintptr_t", "uint", true),
+            ("i8", "int8_t", "int8", true),
+            ("i16", "int16_t", "int16", true),
+            ("i32", "int32_t", "int32", true),
+            ("i64", "int64_t", "int64", true),
+            ("isize", "intptr_t", "int", true),
+            ("f32", "float", "float32", true),
+            ("f64", "double", "float64", true),
+            ("bool", "bool", "bool", true),
+            ("char", "uint32_t", "rune", false),
+        ];
+        assert_eq!(PRIMITIVES.len(), expected.len());
+        for &(rust, c, go, conv) in expected {
+            let info = primitive_by_rust_ident(rust).unwrap();
+            assert_eq!(info.c_name, c, "c_name of {rust}");
+            assert_eq!(info.go_name, go, "go_name of {rust}");
+            assert_eq!(info.has_go_converters, conv, "has_go_converters of {rust}");
+        }
     }
 
     #[test]

--- a/rust2go-macro/src/lib.rs
+++ b/rust2go-macro/src/lib.rs
@@ -2,6 +2,7 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
+use rust2go_common::common::{classify_ref_field, RefFieldClass};
 use rust2go_common::{g2r::G2RTraitRepr, r2g::R2GTraitRepr, sbail};
 use syn::{parse::Parser, parse_macro_input, DeriveInput, Ident};
 
@@ -32,18 +33,17 @@ pub fn r2g_derive(input: TokenStream) -> TokenStream {
         let Some(first_seg) = path.path.segments.first() else {
             return TokenStream::default();
         };
-        match first_seg.ident.to_string().as_str() {
-            "Vec" | "Option" => {
+        match classify_ref_field(&first_seg.ident) {
+            RefFieldClass::List => {
                 ref_fields.push(quote! {#name: ::rust2go::ListRef});
             }
-            "String" => {
+            RefFieldClass::String => {
                 ref_fields.push(quote! {#name: ::rust2go::StringRef});
             }
-            "i8" | "i16" | "i32" | "i64" | "isize" | "u8" | "u16" | "u32" | "u64" | "usize"
-            | "f32" | "f64" | "bool" | "char" => {
+            RefFieldClass::Primitive => {
                 ref_fields.push(quote! {#name: #ty});
             }
-            _ => {
+            RefFieldClass::Custom => {
                 // Use the associated type form so type aliases also work: the
                 // alias itself cannot be resolved here, but its underlying
                 // type implements `ToRef`.


### PR DESCRIPTION
## Summary

Codegen dedup (refactoring plan task 2.1). Pure refactor — **zero behavior change**: generated Go bindings and Rust bindings stay byte-identical.

### A. Single primitive type table

The primitive mappings (Rust ident ↔ C name ↔ Go name, plus classification) were scattered across `rust2go-common/src/common.rs` (5+ separate `match` statements), `rust2go-macro/src/lib.rs` (hardcoded ident list in `r2g_derive`) and `rust2go-convert/src/convert.rs` (the `primitive_impl!` type list).

- New module `rust2go-convert/src/primitive.rs` (the lowest shared crate — it has no dependencies) hosts `PrimitiveInfo { rust_ident, c_name, go_name, has_go_converters }`, the `pub static PRIMITIVES` table, and `primitive_by_rust_ident()`.
- A single `with_primitives!` macro list drives **both** the table and the `ToRef`/`FromRef` impls in `convert.rs`, so the runtime impl set and the table cannot drift.
- `rust2go-common` gains a dependency edge on `rust2go-convert` (clean: no cycle, no new external deps) and replaces all six mapping matches (`to_c`, `to_go`, `c_to_go_field_converter`, `c_to_go_field_converter_owned`, `go_to_c_field_counter`, `go_to_c_field_converter`) plus its two primitive-classification sites with table lookups. The Go converter names are derived as `newC_`/`cntC_`/`refC_` + C name, matching the previous literals exactly.

### B. Unified ref-struct expansion paths

New shared `classify_ref_field()` / `RefFieldClass` in `rust2go-common` now classifies field types (Primitive / String / List / Custom) for **both** the CLI path (`ParamType::try_from`, `convert_structs_levels`) and the `#[derive(R2G)]` proc-macro path, so the two paths can no longer drift. The macro keeps emitting the exact same tokens (including the `<T as ::rust2go::ToRef>::Ref` associated-type fallback for type aliases, and skipping generics/enums).

### Behavior preservation notes

- Per-site panic messages are kept verbatim (including the existing `unreconigzed` typos).
- `char` still maps to `uint32_t`/`rune` but still has no Go field converters (new `has_go_converters` flag), preserving the current panic behavior.
- `Cargo.lock` updated for the new `rust2go-common → rust2go-convert` edge.

No local toolchain was available; verification is expected from CI (`cargo check/test`, `cargo fmt --check`, clippy, gen.go freshness).
