### PR TITLE
refactor: harden mem-ring Go runtime with stop guards and error returns (task 3.2)

### DIFF
--- a/mem-ring/README.md
+++ b/mem-ring/README.md
@@ -4,6 +4,8 @@ A ring based on shared memory bridging rust and go. It support both tokio and mo
 
 With 2 rings, users can simulate calls between rust and go(Both sides can start calls).
 
+The Go package (`mem-ring`) is unix-only (`//go:build unix`): it relies on `x/sys/unix` and socketpair fds, and does not compile on Windows.
+
 ## How it Works
 TODO
 
@@ -30,4 +32,10 @@ mem-ring = { version = "0.1" }
 ## Custom Waiter (Go side)
 
 `ReadQueue.RunHandler(handler, w ...TinyWaiter)` consumes the queue in a loop and yields the CPU through a `TinyWaiter` (see `waiter.go`) while there is nothing to read. The default is `GoSchedWaiter`, which is based on `runtime.Gosched`. To customize the wait strategy, pass your own implementation of the `TinyWaiter` interface.
+
+## Stopping background goroutines (Go side)
+
+`ReadQueue.RunHandler` returns a `*Guard`, and `Queue.Write` returns a `WriteQueue` with `Stop`/`Done` methods. `Stop` is idempotent: it signals the background goroutine and closes the notification socket so a goroutine blocked in `Awaiter.Wait` wakes up and exits instead of spinning on a dead fd. `Done` returns a channel that closes once the goroutine has fully exited.
+
+`Notifier.Notify`, `Awaiter.Wait` and `NewAwaiter` report errors to make this possible: a closed or broken fd surfaces as an error rather than a silent busy loop.
 

--- a/mem-ring/eventfd.go
+++ b/mem-ring/eventfd.go
@@ -1,8 +1,11 @@
 // Copyright 2024 ihciah. All Rights Reserved.
 
+//go:build unix
+
 package mem_ring
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"syscall"
@@ -19,14 +22,16 @@ func NewNotifier(fd int32) Notifier {
 	return Notifier{fd: fd}
 }
 
-func (n Notifier) Notify() {
+// Notify writes one byte to the socketpair peer. It returns the write error,
+// if any; a closed or broken fd is reported instead of being retried forever.
+func (n Notifier) Notify() error {
 	val := uint8(0)
 	for {
 		_, e := syscall.Write(int(n.fd), (*(*[1]byte)(unsafe.Pointer(&val)))[:])
 		if e == unix.EINTR {
 			continue
 		}
-		return
+		return e
 	}
 }
 
@@ -35,16 +40,31 @@ type Awaiter struct {
 	c   net.Conn
 }
 
-func NewAwaiter(fd int32) Awaiter {
+// NewAwaiter takes ownership of fd: the original fd is closed once the
+// connection (which holds a duplicate of it) has been established.
+func NewAwaiter(fd int32) (Awaiter, error) {
 	f := os.NewFile(uintptr(fd), "fd")
 	c, e := net.FileConn(f)
 	if e != nil {
-		panic(e)
+		return Awaiter{}, fmt.Errorf("mem_ring: build awaiter from fd %d: %w", fd, e)
 	}
+	// FileConn duplicated the fd; close the original explicitly. Otherwise
+	// the os.File finalizer would close it at an arbitrary GC point, which
+	// may hit a reused, unrelated fd number.
+	f.Close()
 	var buf [64]byte
-	return Awaiter{buf, c}
+	return Awaiter{buf, c}, nil
 }
 
-func (n *Awaiter) Wait() {
-	n.c.Read(n.buf[:])
+// Wait blocks until the peer notifies or the socket is closed. A closed or
+// broken socket returns the read error so callers can exit instead of
+// spinning on a dead fd.
+func (n *Awaiter) Wait() error {
+	_, e := n.c.Read(n.buf[:])
+	return e
+}
+
+// Close closes the underlying connection, unblocking any pending Wait.
+func (n *Awaiter) Close() error {
+	return n.c.Close()
 }

--- a/mem-ring/queue.go
+++ b/mem-ring/queue.go
@@ -1,14 +1,59 @@
 // Copyright 2024 ihciah. All Rights Reserved.
 
+//go:build unix
+
 package mem_ring
 
 import (
+	"io"
 	"sync"
 	"sync/atomic"
 	"unsafe"
 
 	"github.com/edwingeng/deque/v2"
 )
+
+// Guard controls the lifetime of the background goroutine started by
+// ReadQueue.RunHandler or Queue.Write.
+type Guard struct {
+	stop    chan struct{}
+	stopped chan struct{}
+	once    sync.Once
+	closer  io.Closer
+}
+
+func newGuard(closer io.Closer) *Guard {
+	return &Guard{
+		stop:    make(chan struct{}),
+		stopped: make(chan struct{}),
+		closer:  closer,
+	}
+}
+
+// Stop requests the background goroutine to exit and closes the notification
+// socket so a goroutine blocked in Wait wakes up. It is idempotent and does
+// not wait for the goroutine to finish; use Done for that.
+func (g *Guard) Stop() {
+	g.once.Do(func() {
+		close(g.stop)
+		g.closer.Close()
+	})
+}
+
+// Done returns a channel that is closed once the background goroutine has
+// fully exited.
+func (g *Guard) Done() <-chan struct{} {
+	return g.stopped
+}
+
+func (g *Guard) exiting() bool {
+	select {
+	case <-g.stop:
+		return true
+	default:
+		return false
+	}
+}
 
 type QueueMeta struct {
 	BufferPtr  uintptr
@@ -33,8 +78,7 @@ type Queue[T any] struct {
 }
 
 type ReadQueue[T any] struct {
-	q               Queue[T]
-	unstuckNotifier Notifier
+	q Queue[T]
 }
 
 type WriteQueue[T any] struct {
@@ -42,6 +86,7 @@ type WriteQueue[T any] struct {
 	Lock            *sync.Mutex
 	pendingTasks    *deque.Deque[T]
 	workingNotifier Notifier
+	guard           *Guard
 }
 
 func NewQueue[T any](meta QueueMeta) Queue[T] {
@@ -115,36 +160,35 @@ func (q *Queue[T]) working() bool {
 	return atomic.LoadUint32(q.workingPtr) == 1
 }
 
+// markStuck tells the peer reader that this writer has pending tasks; the
+// peer clears the flag and notifies the unstuck fd when it drains the ring.
 func (q *Queue[T]) markStuck() {
 	atomic.StoreUint32(q.stuckPtr, 1)
 }
 
-func (q *Queue[T]) markUnstuck() {
-	atomic.StoreUint32(q.stuckPtr, 0)
-}
-
-func (q *Queue[T]) stuck() bool {
-	return atomic.LoadUint32(q.stuckPtr) == 1
-}
-
 func (q Queue[T]) Read() ReadQueue[T] {
-	unstuckNotifier := NewNotifier(q.unstuckFd)
-	return ReadQueue[T]{
-		q,
-		unstuckNotifier,
-	}
+	return ReadQueue[T]{q: q}
 }
 
 func (q Queue[T]) Write() WriteQueue[T] {
-	awaiter := NewAwaiter(q.unstuckFd)
+	awaiter, err := NewAwaiter(q.unstuckFd)
+	if err != nil {
+		panic(err)
+	}
+	guard := newGuard(&awaiter)
 	wq := WriteQueue[T]{
 		q:               q,
 		Lock:            &sync.Mutex{},
 		pendingTasks:    deque.NewDeque[T](),
 		workingNotifier: NewNotifier(q.workingFd),
+		guard:           guard,
 	}
 	go func() {
+		defer close(guard.stopped)
 		for {
+			if guard.exiting() {
+				return
+			}
 			wq.Lock.Lock()
 			for item, ok := wq.pendingTasks.TryPopFront(); ok; item, ok = wq.pendingTasks.TryPopFront() {
 				if !wq.q.push(item) {
@@ -154,7 +198,9 @@ func (q Queue[T]) Write() WriteQueue[T] {
 			}
 			if !wq.q.working() {
 				wq.q.markWorking()
-				wq.workingNotifier.Notify()
+				// Best effort: if the peer is gone, the next Wait reports
+				// the broken fd and this goroutine exits.
+				_ = wq.workingNotifier.Notify()
 			}
 			if !wq.pendingTasks.IsEmpty() {
 				wq.q.markStuck()
@@ -166,22 +212,46 @@ func (q Queue[T]) Write() WriteQueue[T] {
 				}
 			}
 			wq.Lock.Unlock()
-			awaiter.Wait()
+			if err := awaiter.Wait(); err != nil {
+				// The socket was closed by Stop or is broken; exit instead
+				// of spinning on a dead fd.
+				return
+			}
 		}
 	}()
 	return wq
 }
 
-func (rq *ReadQueue[T]) RunHandler(handler func(T), w ...TinyWaiter) {
-	// TODO: return channel-based guard
+// Stop shuts down the background flusher goroutine. Items still in
+// pendingTasks are not flushed after Stop.
+func (wq *WriteQueue[T]) Stop() {
+	wq.guard.Stop()
+}
+
+// Done returns a channel that is closed once the background flusher
+// goroutine has fully exited.
+func (wq *WriteQueue[T]) Done() <-chan struct{} {
+	return wq.guard.Done()
+}
+
+// RunHandler consumes items from the queue in a background goroutine and
+// returns a Guard that stops it. While the queue is empty the goroutine
+// yields the CPU through the given TinyWaiter (GoSchedWaiter by default)
+// and then blocks on the working fd until the peer writer notifies.
+func (rq *ReadQueue[T]) RunHandler(handler func(T), w ...TinyWaiter) *Guard {
 	var waiter TinyWaiter
 	if len(w) == 0 {
 		waiter = &GoSchedWaiter{}
 	} else {
 		waiter = w[0]
 	}
+	awaiter, err := NewAwaiter(rq.q.workingFd)
+	if err != nil {
+		panic(err)
+	}
+	guard := newGuard(&awaiter)
 	go func() {
-		awaiter := NewAwaiter(rq.q.workingFd)
+		defer close(guard.stopped)
 		rq.q.markWorking()
 		var waited bool
 	c:
@@ -194,6 +264,9 @@ func (rq *ReadQueue[T]) RunHandler(handler func(T), w ...TinyWaiter) {
 			waiter.Reset(cnt, waited)
 			waited = false
 			for {
+				if guard.exiting() {
+					return
+				}
 				stop_wait := waiter.Wait()
 				if !rq.q.isEmpty() || !rq.q.markUnworking() {
 					continue c
@@ -203,11 +276,19 @@ func (rq *ReadQueue[T]) RunHandler(handler func(T), w ...TinyWaiter) {
 				}
 			}
 
-			awaiter.Wait()
+			if err := awaiter.Wait(); err != nil {
+				// The socket was closed by Stop or is broken; exit instead
+				// of spinning on a dead fd.
+				return
+			}
+			if guard.exiting() {
+				return
+			}
 			rq.q.markWorking()
 			waited = true
 		}
 	}()
+	return guard
 }
 
 func (wq *WriteQueue[T]) Push(item T) {
@@ -216,7 +297,7 @@ func (wq *WriteQueue[T]) Push(item T) {
 		if !wq.q.working() {
 			wq.q.markWorking()
 			wq.Lock.Unlock()
-			wq.workingNotifier.Notify()
+			_ = wq.workingNotifier.Notify()
 			return
 		}
 	} else {

--- a/mem-ring/queue_test.go
+++ b/mem-ring/queue_test.go
@@ -256,7 +256,8 @@ func TestWriteQueueExitsOnBrokenFd(t *testing.T) {
 // channel without Stop being called, instead of spinning on the dead fd.
 func TestRunHandlerExitsOnBrokenFd(t *testing.T) {
 	q, workingPeer, _ := newFdQueue[uint64](t, 8)
-	guard := q.Read().RunHandler(func(uint64) {})
+	rq := q.Read()
+	guard := rq.RunHandler(func(uint64) {})
 	// Closing the peer end makes the awaiter's next read report EOF.
 	workingPeer.Close()
 	waitStopped(t, guard.Done())

--- a/mem-ring/queue_test.go
+++ b/mem-ring/queue_test.go
@@ -282,7 +282,17 @@ func TestRunHandlerStop(t *testing.T) {
 	}
 	rq := q.Read()
 	got := make(chan uint64, 1)
-	guard := rq.RunHandler(func(v uint64) { got <- v })
+	var mu sync.Mutex
+	var vals []uint64
+	guard := rq.RunHandler(func(v uint64) {
+		mu.Lock()
+		vals = append(vals, v)
+		mu.Unlock()
+		select {
+		case got <- v:
+		default:
+		}
+	})
 	select {
 	case v := <-got:
 		if v != 7 {
@@ -295,6 +305,12 @@ func TestRunHandlerStop(t *testing.T) {
 	waitStopped(t, guard.Done())
 	// Stop is idempotent.
 	guard.Stop()
+	mu.Lock()
+	defer mu.Unlock()
+	if len(vals) != 1 {
+		t.Fatalf("handler called %d times, want 1: vals=%v head=%d tail=%d",
+			len(vals), vals, atomic.LoadUint64(q.headPtr), atomic.LoadUint64(q.tailPtr))
+	}
 }
 
 // NewQueue must wire QueueMeta pointers up the same way as manual

--- a/mem-ring/queue_test.go
+++ b/mem-ring/queue_test.go
@@ -193,26 +193,38 @@ func newFdPair(t *testing.T) (int32, *testFd) {
 	return int32(fds[0]), b
 }
 
+// fdQueueState keeps the ring memory and counters in one heap-allocated
+// struct referenced by real pointers. Routing them through QueueMeta's
+// uintptr fields would escape the GC's liveness tracking and risk the
+// backing storage being reclaimed or the stack frame reused (see the
+// unsafe.Pointer rules on uintptr conversions).
+type fdQueueState[T any] struct {
+	buf     []T
+	head    uint64
+	tail    uint64
+	working uint32
+	stuck   uint32
+}
+
 // newFdQueue builds a Queue over local memory with real socketpair fds so
 // the Write/RunHandler goroutines and their stop mechanism can be tested.
 // It returns the queue and the peer ends of the working/unstuck channels.
+// The returned Queue keeps the state alive via its pointer fields.
 func newFdQueue[T any](t *testing.T, n int) (q Queue[T], workingPeer, unstuckPeer *testFd) {
 	t.Helper()
-	buf := make([]T, n)
-	var head, tail uint64
-	var working, stuck uint32
+	state := &fdQueueState[T]{buf: make([]T, n)}
 	workingFd, wp := newFdPair(t)
 	unstuckFd, up := newFdPair(t)
-	return NewQueue[T](QueueMeta{
-		BufferPtr:  uintptr(unsafe.Pointer(&buf[0])),
-		BufferLen:  uintptr(n),
-		HeadPtr:    uintptr(unsafe.Pointer(&head)),
-		TailPtr:    uintptr(unsafe.Pointer(&tail)),
-		WorkingPtr: uintptr(unsafe.Pointer(&working)),
-		StuckPtr:   uintptr(unsafe.Pointer(&stuck)),
-		WorkingFd:  workingFd,
-		UnstuckFd:  unstuckFd,
-	}), wp, up
+	return Queue[T]{
+		bufferPtr:  unsafe.Pointer(&state.buf[0]),
+		bufferLen:  uintptr(n),
+		headPtr:    &state.head,
+		tailPtr:    &state.tail,
+		workingPtr: &state.working,
+		stuckPtr:   &state.stuck,
+		workingFd:  workingFd,
+		unstuckFd:  unstuckFd,
+	}, wp, up
 }
 
 func waitStopped(t *testing.T, done <-chan struct{}) {
@@ -317,16 +329,16 @@ func TestRunHandlerStop(t *testing.T) {
 // construction (fds are irrelevant for push/pop and left unset).
 func TestNewQueueFromMeta(t *testing.T) {
 	const n = 8
-	buf := make([]uint64, n)
-	var head, tail uint64
-	var working, stuck uint32
+	// Heap-allocated state kept alive across the QueueMeta uintptr
+	// conversions; see fdQueueState for why real liveness matters here.
+	state := &fdQueueState[uint64]{buf: make([]uint64, n)}
 	q := NewQueue[uint64](QueueMeta{
-		BufferPtr:  uintptr(unsafe.Pointer(&buf[0])),
+		BufferPtr:  uintptr(unsafe.Pointer(&state.buf[0])),
 		BufferLen:  n,
-		HeadPtr:    uintptr(unsafe.Pointer(&head)),
-		TailPtr:    uintptr(unsafe.Pointer(&tail)),
-		WorkingPtr: uintptr(unsafe.Pointer(&working)),
-		StuckPtr:   uintptr(unsafe.Pointer(&stuck)),
+		HeadPtr:    uintptr(unsafe.Pointer(&state.head)),
+		TailPtr:    uintptr(unsafe.Pointer(&state.tail)),
+		WorkingPtr: uintptr(unsafe.Pointer(&state.working)),
+		StuckPtr:   uintptr(unsafe.Pointer(&state.stuck)),
 	})
 	for i := uint64(0); i < n; i++ {
 		if !q.push(i + 100) {
@@ -342,7 +354,8 @@ func TestNewQueueFromMeta(t *testing.T) {
 			t.Fatalf("pop %d = %v, want %d", i, item, i+100)
 		}
 	}
-	if head != n || tail != n {
-		t.Fatalf("head/tail = %d/%d, want %d/%d", head, tail, n, n)
+	if state.head != n || state.tail != n {
+		t.Fatalf("head/tail = %d/%d, want %d/%d", state.head, state.tail, n, n)
 	}
+	runtime.KeepAlive(state)
 }

--- a/mem-ring/queue_test.go
+++ b/mem-ring/queue_test.go
@@ -5,6 +5,7 @@
 package mem_ring
 
 import (
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -219,7 +220,9 @@ func waitStopped(t *testing.T, done <-chan struct{}) {
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		t.Fatal("background goroutine did not exit after Stop")
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+		t.Fatalf("background goroutine did not exit after Stop\ngoroutines:\n%s", buf[:n])
 	}
 }
 
@@ -235,8 +238,13 @@ func TestWriteQueueStop(t *testing.T) {
 	wq.Stop()
 	// The item pushed before Stop stays in the ring.
 	item := q.pop()
-	if item == nil || *item != 42 {
-		t.Fatalf("pop = %v, want 42", item)
+	if item == nil {
+		t.Fatalf("pop = nil, want 42 (head=%d tail=%d)",
+			atomic.LoadUint64(q.headPtr), atomic.LoadUint64(q.tailPtr))
+	}
+	if *item != 42 {
+		t.Fatalf("pop = %d, want 42 (head=%d tail=%d)",
+			*item, atomic.LoadUint64(q.headPtr), atomic.LoadUint64(q.tailPtr))
 	}
 }
 

--- a/mem-ring/queue_test.go
+++ b/mem-ring/queue_test.go
@@ -1,10 +1,18 @@
 // Copyright 2024 ihciah. All Rights Reserved.
 
+//go:build unix
+
 package mem_ring
 
 import (
+	"sync"
+	"sync/atomic"
+	"syscall"
 	"testing"
+	"time"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 // newTestQueue builds a Queue over locally allocated memory so the pure
@@ -146,19 +154,138 @@ func TestQueueWorkingFlags(t *testing.T) {
 	}
 }
 
-func TestQueueStuckFlags(t *testing.T) {
+func TestQueueMarkStuck(t *testing.T) {
 	q, _ := newTestQueue[uint64](2)
-	if q.stuck() {
-		t.Fatal("new queue is stuck")
+	if got := atomic.LoadUint32(q.stuckPtr); got != 0 {
+		t.Fatalf("new queue stuck flag = %d, want 0", got)
 	}
 	q.markStuck()
-	if !q.stuck() {
-		t.Fatal("stuck() false after markStuck")
+	if got := atomic.LoadUint32(q.stuckPtr); got != 1 {
+		t.Fatalf("stuck flag = %d after markStuck, want 1", got)
 	}
-	q.markUnstuck()
-	if q.stuck() {
-		t.Fatal("stuck() true after markUnstuck")
+}
+
+// testFd wraps an fd so tests and cleanups can close it idempotently:
+// closing the same fd number twice risks closing an unrelated reused fd.
+type testFd struct {
+	fd   int32
+	once sync.Once
+}
+
+func (f *testFd) Close() {
+	f.once.Do(func() { syscall.Close(int(f.fd)) })
+}
+
+// newFdPair returns a connected unix socketpair like the Rust side creates
+// for the working/unstuck notification channels. The queue-side fd gets no
+// cleanup: NewAwaiter takes ownership of it and closes it (and any fd only
+// wrapped by a Notifier is leaked until the test process exits). Only the
+// peer end is closed idempotently via testFd.
+func newFdPair(t *testing.T) (int32, *testFd) {
+	t.Helper()
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
 	}
+	b := &testFd{fd: int32(fds[1])}
+	t.Cleanup(b.Close)
+	return int32(fds[0]), b
+}
+
+// newFdQueue builds a Queue over local memory with real socketpair fds so
+// the Write/RunHandler goroutines and their stop mechanism can be tested.
+// It returns the queue and the peer ends of the working/unstuck channels.
+func newFdQueue[T any](t *testing.T, n int) (q Queue[T], workingPeer, unstuckPeer *testFd) {
+	t.Helper()
+	buf := make([]T, n)
+	var head, tail uint64
+	var working, stuck uint32
+	workingFd, wp := newFdPair(t)
+	unstuckFd, up := newFdPair(t)
+	return NewQueue[T](QueueMeta{
+		BufferPtr:  uintptr(unsafe.Pointer(&buf[0])),
+		BufferLen:  uintptr(n),
+		HeadPtr:    uintptr(unsafe.Pointer(&head)),
+		TailPtr:    uintptr(unsafe.Pointer(&tail)),
+		WorkingPtr: uintptr(unsafe.Pointer(&working)),
+		StuckPtr:   uintptr(unsafe.Pointer(&stuck)),
+		WorkingFd:  workingFd,
+		UnstuckFd:  unstuckFd,
+	}), wp, up
+}
+
+func waitStopped(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("background goroutine did not exit after Stop")
+	}
+}
+
+// Stop must terminate the blocked flusher goroutine instead of letting it
+// wait on the unstuck fd forever.
+func TestWriteQueueStop(t *testing.T) {
+	q, _, _ := newFdQueue[uint64](t, 8)
+	wq := q.Write()
+	wq.Push(42)
+	wq.Stop()
+	waitStopped(t, wq.Done())
+	// Stop is idempotent.
+	wq.Stop()
+	// The item pushed before Stop stays in the ring.
+	item := q.pop()
+	if item == nil || *item != 42 {
+		t.Fatalf("pop = %v, want 42", item)
+	}
+}
+
+// The flusher goroutine must also exit when the peer closes the unstuck
+// channel without Stop being called, instead of spinning on the dead fd.
+func TestWriteQueueExitsOnBrokenFd(t *testing.T) {
+	q, _, unstuckPeer := newFdQueue[uint64](t, 8)
+	wq := q.Write()
+	// Closing the peer end makes the awaiter's next read report EOF.
+	unstuckPeer.Close()
+	waitStopped(t, wq.Done())
+	// Closing the guard afterwards is still safe and idempotent.
+	wq.Stop()
+}
+
+// The handler goroutine must also exit when the peer closes the working
+// channel without Stop being called, instead of spinning on the dead fd.
+func TestRunHandlerExitsOnBrokenFd(t *testing.T) {
+	q, workingPeer, _ := newFdQueue[uint64](t, 8)
+	guard := q.Read().RunHandler(func(uint64) {})
+	// Closing the peer end makes the awaiter's next read report EOF.
+	workingPeer.Close()
+	waitStopped(t, guard.Done())
+	// Closing the guard afterwards is still safe and idempotent.
+	guard.Stop()
+}
+
+// Stop must terminate the handler goroutine blocked on the working fd.
+func TestRunHandlerStop(t *testing.T) {
+	q, _, _ := newFdQueue[uint64](t, 8)
+	// Push before starting the handler: the first drain loop picks it up.
+	if !q.push(7) {
+		t.Fatal("push failed on empty queue")
+	}
+	rq := q.Read()
+	got := make(chan uint64, 1)
+	guard := rq.RunHandler(func(v uint64) { got <- v })
+	select {
+	case v := <-got:
+		if v != 7 {
+			t.Fatalf("handler got %d, want 7", v)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not consume the pushed item")
+	}
+	guard.Stop()
+	waitStopped(t, guard.Done())
+	// Stop is idempotent.
+	guard.Stop()
 }
 
 // NewQueue must wire QueueMeta pointers up the same way as manual

--- a/mem-ring/slab.go
+++ b/mem-ring/slab.go
@@ -1,5 +1,7 @@
 // Copyright 2024 ihciah. All Rights Reserved.
 
+//go:build unix
+
 package mem_ring
 
 import (
@@ -48,33 +50,20 @@ func NewLockedSlab[T any]() *LockedSlab[T] {
 	}
 }
 
-func NewMultiSlab[T any](opts ...MultiSlabOption) *MultiSlab[T] {
-	opt := MultiSlabOpt{
-		SlabSizeExp: 4,
-	}
-	for _, op := range opts {
-		op.apply(&opt)
-	}
+// multiSlabSizeExp is the bit width of the MultiSlab shard count.
+const multiSlabSizeExp = 4
 
-	size := 1 << opt.SlabSizeExp
+func NewMultiSlab[T any]() *MultiSlab[T] {
+	const size = 1 << multiSlabSizeExp
 	slabs := make([]LockedSlab[T], size)
 	for i := 0; i < size; i++ {
 		slabs[i] = *NewLockedSlab[T]()
 	}
 	return &MultiSlab[T]{
 		slabs: slabs,
-		exp:   opt.SlabSizeExp,
-		mask:  1<<opt.SlabSizeExp - 1,
+		exp:   multiSlabSizeExp,
+		mask:  size - 1,
 	}
-}
-
-type MultiSlabOpt struct {
-	// bit width of slab size
-	SlabSizeExp uint
-}
-
-type MultiSlabOption interface {
-	apply(*MultiSlabOpt)
 }
 
 func (s *Slab[T]) Push(data T) uint {

--- a/mem-ring/slab_test.go
+++ b/mem-ring/slab_test.go
@@ -1,5 +1,7 @@
 // Copyright 2024 ihciah. All Rights Reserved.
 
+//go:build unix
+
 package mem_ring
 
 import (

--- a/mem-ring/waiter.go
+++ b/mem-ring/waiter.go
@@ -1,10 +1,11 @@
 // Copyright 2024 ihciah. All Rights Reserved.
 
+//go:build unix
+
 package mem_ring
 
 import (
 	"runtime"
-	"time"
 )
 
 type TinyWaiter interface {
@@ -19,20 +20,4 @@ func (w *GoSchedWaiter) Reset(_ uint, _ bool) {}
 func (w *GoSchedWaiter) Wait() bool {
 	runtime.Gosched()
 	return true
-}
-
-type SleepWaiter struct {
-	Interval time.Duration
-	Max      time.Duration
-	Current  time.Duration
-}
-
-func (w *SleepWaiter) Reset(_ uint, _ bool) {
-	w.Current = 0
-}
-
-func (w *SleepWaiter) Wait() bool {
-	time.Sleep(w.Interval)
-	w.Current += w.Interval
-	return w.Current > w.Max
 }

--- a/rust2go-mem-ffi/src/lib.rs
+++ b/rust2go-mem-ffi/src/lib.rs
@@ -41,11 +41,6 @@ pub struct Payload {
     // 3. 0b1000=only drop(for response)
     // For a oneway call: send 1, recv 3
     // For a normal call: send 1, recv 2, send 3
-    // last 5th bit: want peer quit
-    // so:
-    // 1. 0b10100=notify peer to quit and wait peer quit reply
-    // 2. 0b10000=notify peer to quit
-    // For a quit call: send 1, recv 2
     pub flag: u32,
 }
 
@@ -53,8 +48,6 @@ impl Payload {
     const CALL: u32 = 0b0101;
     const REPLY: u32 = 0b1110;
     const DROP: u32 = 0b1000;
-    const QUIT_INIT: u32 = 0b10100;
-    const QUIT_ACK: u32 = 0b10000;
 
     #[inline]
     pub const fn new_call(call_id: u32, user_data: usize, ptr: usize) -> Self {
@@ -88,28 +81,6 @@ impl Payload {
             flag: Self::DROP,
         }
     }
-
-    #[inline]
-    pub const fn new_quit_init() -> Self {
-        Self {
-            ptr: 0,
-            user_data: 0,
-            next_user_data: 0,
-            call_id: 0,
-            flag: Self::QUIT_INIT,
-        }
-    }
-
-    #[inline]
-    pub const fn new_quit_ack() -> Self {
-        Self {
-            ptr: 0,
-            user_data: 0,
-            next_user_data: 0,
-            call_id: 0,
-            flag: Self::QUIT_ACK,
-        }
-    }
 }
 
 pub struct TaskDesc {
@@ -138,9 +109,6 @@ pub unsafe fn init_mem_ffi<const N: usize>(
     let sb = shared_slab.clone();
     let guard = read_queue
         .run_handler(move |payload: Payload| {
-            if payload.flag & Payload::QUIT_ACK == Payload::QUIT_ACK {
-                return;
-            }
             let Some(call_handle) = handlers.get(payload.call_id as usize) else {
                 panic!("call handler {} not found", payload.call_id);
             };
@@ -240,47 +208,19 @@ mod tests {
     }
 
     #[test]
-    fn payload_new_quit() {
-        let init = Payload::new_quit_init();
-        assert_eq!(init.ptr, 0);
-        assert_eq!(init.user_data, 0);
-        assert_eq!(init.next_user_data, 0);
-        assert_eq!(init.call_id, 0);
-        assert_eq!(init.flag, 0b10100);
-
-        let ack = Payload::new_quit_ack();
-        assert_eq!(ack.ptr, 0);
-        assert_eq!(ack.user_data, 0);
-        assert_eq!(ack.next_user_data, 0);
-        assert_eq!(ack.call_id, 0);
-        assert_eq!(ack.flag, 0b10000);
-    }
-
-    #[test]
     fn payload_flag_protocol() {
         let call = Payload::new_call(0, 0, 0).flag;
         let reply = Payload::new_reply(0, 0, 0, 0).flag;
         let drop = Payload::new_drop(0, 0).flag;
-        let quit_init = Payload::new_quit_init().flag;
-        let quit_ack = Payload::new_quit_ack().flag;
 
         // These constants are part of the wire protocol with the Go side
         // (see go_shm_ring_init codegen: CALL=0b0101, REPLY=0b1110, DROP=0b1000).
         assert_eq!(call, 0b0101);
         assert_eq!(reply, 0b1110);
         assert_eq!(drop, 0b1000);
-        assert_eq!(quit_init, 0b10100);
-        assert_eq!(quit_ack, 0b10000);
 
-        // The dispatcher in init_mem_ffi ignores payloads whose QUIT_ACK bit
-        // is set; QUIT_INIT also carries that bit.
-        assert_eq!(quit_init & quit_ack, quit_ack);
-        assert_ne!(call & quit_ack, quit_ack);
-        assert_ne!(reply & quit_ack, quit_ack);
-        assert_ne!(drop & quit_ack, quit_ack);
-
-        // All five flags must be distinct.
-        let flags = [call, reply, drop, quit_init, quit_ack];
+        // All flags must be distinct.
+        let flags = [call, reply, drop];
         for (i, a) in flags.iter().enumerate() {
             for b in &flags[i + 1..] {
                 assert_ne!(a, b);


### PR DESCRIPTION
## What

Task 3.2 of the refactor plan: mem-ring robustness and cleanup.

**Go side (`mem-ring` package):**
- `Notifier.Notify`, `Awaiter.Wait`, `NewAwaiter` now return errors; a closed or broken fd surfaces as an error instead of a silent busy loop
- `NewAwaiter` takes fd ownership and closes the original fd explicitly after `net.FileConn` duplicates it, so the `os.File` finalizer cannot close a reused fd number at an arbitrary GC point
- New `Guard` (stop channel + idempotent `Stop` + `Done`) backs both `ReadQueue.RunHandler` (resolving the `TODO: return channel-based guard`) and the `WriteQueue` flusher goroutine; `Stop` closes the notification socket so a goroutine blocked in `Wait` wakes up and exits
- Dead code removed: `unstuckNotifier`, `markUnstuck`/`stuck` (the Go reader never notified; `markStuck` stays — the Rust peer reads `stuck_ptr` for flow control), `SleepWaiter`, `MultiSlabOption`
- The package is now `//go:build unix`-constrained (it depends on `x/sys/unix` + socketpair and never compiled on Windows)

**Rust side (`rust2go-mem-ffi`):**
- Removed the superseded quit-flag protocol: `Payload::new_quit_init`/`new_quit_ack`, the `QUIT_INIT`/`QUIT_ACK` constants, and the `QUIT_ACK` early-return in the `init_mem_ffi` dispatcher (no peer ever emitted these flags; the Rust side already stops handlers via channel-based `Guard`)

**Tests:** new socketpair-based tests cover `Stop` terminating both goroutines, exit on peer-closed fd (writer and reader), `Stop` idempotency, and item delivery before stop. `TestQueueMarkStuck` keeps coverage of the retained `markStuck`.

**Docs:** mem-ring README documents the unix-only constraint, the error-returning primitives, and the `Guard`/`Stop`/`Done` lifecycle.

Codegen templates and `test/go/gen.go` are untouched: `gr.RunHandler(...)` remains a valid expression statement discarding the single `*Guard` return, so the gen.go freshness check is unaffected.