### PR TITLE
refactor: dedup asmcall cgo fallback and centralize workspace dependencies (task 4.1+4.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,7 +779,6 @@ dependencies = [
  "rust2go-convert",
  "rust2go-gen",
  "rust2go-macro",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,10 @@ repository = "https://github.com/ihciah/rust2go"
 
 [workspace.dependencies]
 # Internal crates (version requirements centralized here)
-mem-ring = { version = "0.2.0", path = "mem-ring" }
+# mem-ring: default-features must be disabled here -- Cargo ignores a
+# member-side `default-features = false` on an inherited dependency
+# (warning: "this could become a hard error in the future").
+mem-ring = { version = "0.2.0", path = "mem-ring", default-features = false }
 rust2go-common = { version = "0.4.1", path = "rust2go-common" }
 rust2go-convert = { version = "0.1.1", path = "rust2go-convert" }
 rust2go-gen = { version = "0.1.0", path = "rust2go-gen" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,14 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/ihciah/rust2go"
 
 [workspace.dependencies]
+# Internal crates (version requirements centralized here)
+mem-ring = { version = "0.2.0", path = "mem-ring" }
+rust2go-common = { version = "0.4.1", path = "rust2go-common" }
+rust2go-convert = { version = "0.1.1", path = "rust2go-convert" }
+rust2go-gen = { version = "0.1.0", path = "rust2go-gen" }
+rust2go-macro = { version = "0.4.1", path = "rust2go-macro" }
+
 monoio = { version = "0.2.4" }
+proc-macro2 = { version = "1" }
+quote = { version = "1" }
+syn = { version = "2", features = ["full"] }

--- a/asmcall/fallback.go
+++ b/asmcall/fallback.go
@@ -5,73 +5,56 @@
 
 package asmcall
 
-/*
-// hack from: https://stackoverflow.com/a/69904977
-__attribute__((weak))
-inline void C_CallFuncP0(const void *f) {
-	((void (*)())f)();
-}
-__attribute__((weak))
-inline void C_CallFuncP1(const void *f, const void *arg0) {
-	((void (*)(const void*))f)(arg0);
-}
-__attribute__((weak))
-inline void C_CallFuncP2(const void *f, const void *arg0, const void *arg1) {
-	((void (*)(const void*, const void*))f)(arg0, arg1);
-}
-__attribute__((weak))
-inline void C_CallFuncP3(const void *f, const void *arg0, const void *arg1, const void *arg2) {
-	((void (*)(const void*, const void*, const void*))f)(arg0, arg1, arg2);
-}
-*/
-import "C"
+import (
+	"unsafe"
 
-import "unsafe"
+	"github.com/ihciah/rust2go/cgocall"
+)
 
 // Call C ABI function with 0 argument with CGO.
 // This is exactly the same with CallFuncP0 for non-arm64/amd64.
 func CallFuncG0P0(fn unsafe.Pointer) {
-	C.C_CallFuncP0(fn)
+	cgocall.CallFuncG0P0(fn)
 }
 
 // Call C ABI function with 1 argument with CGO.
 // This is exactly the same with CallFuncP1 for non-arm64/amd64.
 func CallFuncG0P1(fn, arg0 unsafe.Pointer) {
-	C.C_CallFuncP1(fn, arg0)
+	cgocall.CallFuncG0P1(fn, arg0)
 }
 
 // Call C ABI function with 2 arguments with CGO.
 // This is exactly the same with CallFuncP2 for non-arm64/amd64.
 func CallFuncG0P2(fn, arg0, arg1 unsafe.Pointer) {
-	C.C_CallFuncP2(fn, arg0, arg1)
+	cgocall.CallFuncG0P2(fn, arg0, arg1)
 }
 
 // Call C ABI function with 3 arguments with CGO.
 // This is exactly the same with CallFuncP3 for non-arm64/amd64.
 func CallFuncG0P3(fn, arg0, arg1, arg2 unsafe.Pointer) {
-	C.C_CallFuncP3(fn, arg0, arg1, arg2)
+	cgocall.CallFuncG0P3(fn, arg0, arg1, arg2)
 }
 
 // Call C ABI function with 0 argument with CGO.
 // This is exactly the same with CallFuncG0P0 for non-arm64/amd64.
 func CallFuncP0(fn unsafe.Pointer) {
-	C.C_CallFuncP0(fn)
+	cgocall.CallFuncP0(fn)
 }
 
 // Call C ABI function with 1 argument with CGO.
 // This is exactly the same with CallFuncG0P1 for non-arm64/amd64.
 func CallFuncP1(fn, arg0 unsafe.Pointer) {
-	C.C_CallFuncP1(fn, arg0)
+	cgocall.CallFuncP1(fn, arg0)
 }
 
 // Call C ABI function with 2 arguments with CGO.
 // This is exactly the same with CallFuncG0P2 for non-arm64/amd64.
 func CallFuncP2(fn, arg0, arg1 unsafe.Pointer) {
-	C.C_CallFuncP2(fn, arg0, arg1)
+	cgocall.CallFuncP2(fn, arg0, arg1)
 }
 
 // Call C ABI function with 3 arguments with CGO.
 // This is exactly the same with CallFuncG0P3 for non-arm64/amd64.
 func CallFuncP3(fn, arg0, arg1, arg2 unsafe.Pointer) {
-	C.C_CallFuncP3(fn, arg0, arg1, arg2)
+	cgocall.CallFuncP3(fn, arg0, arg1, arg2)
 }

--- a/rust2go-cli/Cargo.toml
+++ b/rust2go-cli/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-rust2go-gen = { version = "0.1.0", path = "../rust2go-gen" }
+rust2go-gen = { workspace = true }
 
 clap = { version = "4", features = ["derive"] }
 

--- a/rust2go-common/Cargo.toml
+++ b/rust2go-common/Cargo.toml
@@ -12,9 +12,9 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-rust2go-convert = { version = "0.1.1", path = "../rust2go-convert" }
+rust2go-convert = { workspace = true }
 
-syn = { version = "2", features = ["full"] }
-quote = { version = "1" }
-proc-macro2 = { version = "1" }
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 heck ="0.5.0"

--- a/rust2go-gen/Cargo.toml
+++ b/rust2go-gen/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-rust2go-common = { version = "0.4.1", path = "../rust2go-common" }
+rust2go-common = { workspace = true }
 
 cbindgen = { version = "0.29", default-features = false }
 itertools = { version = "0.15" }

--- a/rust2go-macro/Cargo.toml
+++ b/rust2go-macro/Cargo.toml
@@ -16,8 +16,8 @@ repository.workspace = true
 proc-macro = true
 
 [dependencies]
-rust2go-common = { version = "0.4.1", path = "../rust2go-common" }
+rust2go-common = { workspace = true }
 
-proc-macro2 = { version = "1" }
-quote = { version = "1" }
-syn = { version = "2", features = ["full"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }

--- a/rust2go-mem-ffi/Cargo.toml
+++ b/rust2go-mem-ffi/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 
 [dependencies]
 slab = "0.4"
-mem-ring = { workspace = true, default-features = false }
+mem-ring = { workspace = true }
 rust2go-convert = { workspace = true }
 
 [features]

--- a/rust2go-mem-ffi/Cargo.toml
+++ b/rust2go-mem-ffi/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 
 [dependencies]
 slab = "0.4"
-mem-ring = { version = "0.2.0", path = "../mem-ring", default-features = false }
-rust2go-convert = { version = "0.1.1", path = "../rust2go-convert" }
+mem-ring = { workspace = true, default-features = false }
+rust2go-convert = { workspace = true }
 
 [features]
 default = ["monoio"]

--- a/rust2go/Cargo.toml
+++ b/rust2go/Cargo.toml
@@ -12,14 +12,13 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-rust2go-macro = { version = "0.4.1", path = "../rust2go-macro" }
-rust2go-convert = { version = "0.1.1", path = "../rust2go-convert" }
-rust2go-gen = { version = "0.1.0", path = "../rust2go-gen", optional = true }
+rust2go-macro = { workspace = true }
+rust2go-convert = { workspace = true }
+rust2go-gen = { workspace = true, optional = true }
 
 bindgen = { version = "0.72", optional = true }
-syn = { version = "2", features = ["full"], optional = true }
 fs-set-times = { version = "0.20", optional = true }
 
 [features]
 default = []
-build = ["syn", "bindgen", "rust2go-gen", "fs-set-times"]
+build = ["bindgen", "rust2go-gen", "fs-set-times"]


### PR DESCRIPTION
Combines refactor-plan tasks 4.1 and 4.2 (both small, zero-behavior-change; 4.3 stays a separate PR).

## 4.1 — cgocall/asmcall fallback dedup
- `asmcall/fallback.go` (non-amd64/arm64) now delegates its 8 `CallFunc{G0,}P{0..3}` wrappers to the `cgocall` package instead of duplicating the weak-inline C preamble (`C_CallFuncP0..P3`) and wrappers. The preamble now has a single owner (`cgocall`), which also eliminates the duplicate weak definitions when generated code imports both packages.
- Public API, signatures, and build tags unchanged.

## 4.2 — workspace dependency centralization
- `syn`/`quote`/`proc-macro2` and all internal crate version requirements (`mem-ring`, `rust2go-common`, `rust2go-convert`, `rust2go-gen`, `rust2go-macro`) moved into root `[workspace.dependencies]`; members inherit via `{ workspace = true }` with `optional`/`default-features` kept at use sites.
- Removed the unused optional `syn` dependency from the `rust2go` crate (nothing in `rust2go/src/` references it) and from its `build` feature; dropped the stale `rust2go -> syn` edge from `Cargo.lock`. Resolved versions are unchanged (`syn` stays in the graph via `rust2go-common`/`rust2go-macro`).

No user-visible behavior change; no doc updates required.