### PR TITLE
fix: repair mem-ring write-side stop signal and Queue::new error-path leak (task 4.6)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,8 @@
-# Codecov gate: the project coverage target is set at the level reached by
-# the task-4.5 test work (97.4% as of 2026-09-08). The remaining misses are
-# defensive/unreachable-by-design code: proc-macro entry points (executed
-# inside rustc, not instrumented by llvm-cov), impossible-state panic arms,
-# the unstuck handler's dead stop branch (see the refactor plan's known
-# issues), and a few race-window paths.
+# Codecov gate: the project coverage target is set at the level reached on
+# 2026-09-08 (97.4%). The remaining misses are defensive or
+# unreachable-by-design code: proc-macro entry points (executed inside
+# rustc, not instrumented by llvm-cov), impossible-state panic arms, and a
+# few race-window paths.
 coverage:
   status:
     project:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -29,7 +29,7 @@ The GitHub Actions workflow (`.github/workflows/ci.yml`) runs four jobs on every
 ### coverage
 
 - `cargo llvm-cov` over the workspace (same feature-matrix exclusions as build-and-test), Go coverage from `test/go`, uploaded to Codecov. The Go toolchain comes from the same `GO_VERSION` (`stable`) as the go job.
-- **Coverage gate**: `codecov.yml` sets a project status check with `target: 97%` and `threshold: 0.5%` — a ratchet at the level reached by the task-4.5 test work. The remaining ~2.6% of misses are defensive or unreachable-by-design code (proc-macro entry points are executed inside rustc and not instrumented, impossible-state panic arms, the mem-ring unstuck handler's dead stop branch — see the known-issues list in `target/REFACTOR_PLAN.md` — and a few race-window paths). There is deliberately no patch-level gate so that adding defensive code is never blocked.
+- **Coverage gate**: `codecov.yml` sets a project status check with `target: 97%` and `threshold: 0.5%` — a ratchet at the level reached on 2026-09-08. The remaining ~2.6% of misses are defensive or unreachable-by-design code (proc-macro entry points are executed inside rustc and not instrumented, impossible-state panic arms, and a few race-window paths). There is deliberately no patch-level gate so that adding defensive code is never blocked.
 
 ### lint
 

--- a/mem-ring/README.md
+++ b/mem-ring/README.md
@@ -39,3 +39,9 @@ mem-ring = { version = "0.1" }
 
 `Notifier.Notify`, `Awaiter.Wait` and `NewAwaiter` report errors to make this possible: a closed or broken fd surfaces as an error rather than a silent busy loop.
 
+## Stopping background tasks (Rust side)
+
+`ReadQueue::run_handler` returns a `Guard`; dropping it stops the read-side handler task. On the write side, `Queue::write` spawns an unstuck handler that flushes pending items; it stops once the **last** `WriteQueue` clone is dropped (all clones share one stop signal), after which pending items are no longer flushed.
+
+One exception: `rust2go-mem-ffi`'s `init_mem_ffi` intentionally keeps both handlers alive forever — it runs once per thread and leaks the read-side guard, and its handler closure holds a `WriteQueue` clone for drop-ack payloads, so the write-side handler never observes the stop signal on that path.
+

--- a/mem-ring/src/queue.rs
+++ b/mem-ring/src/queue.rs
@@ -34,6 +34,25 @@ use crate::{
     util::yield_now,
 };
 
+#[cfg(not(all(feature = "monoio", feature = "tpc")))]
+type SharedInner<T> = Arc<Mutex<WriteQueueInner<T>>>;
+#[cfg(all(feature = "monoio", feature = "tpc"))]
+type SharedInner<T> = Rc<UnsafeCell<WriteQueueInner<T>>>;
+
+#[cfg(not(all(feature = "monoio", feature = "tpc")))]
+type SharedNotifier = Arc<Notifier>;
+#[cfg(all(feature = "monoio", feature = "tpc"))]
+type SharedNotifier = Rc<Notifier>;
+
+// The stop-signal receiver is shared by all user-side WriteQueue clones so
+// that dropping the last clone releases it. The unstuck handler task must
+// NOT hold a reference: `Receiver` is not `Clone`, so it is wrapped in
+// Arc/Rc instead.
+#[cfg(not(all(feature = "monoio", feature = "tpc")))]
+type SharedGuard = Arc<Receiver<()>>;
+#[cfg(all(feature = "monoio", feature = "tpc"))]
+type SharedGuard = Rc<Receiver<()>>;
+
 pub struct Guard {
     _rx: Receiver<()>,
 }
@@ -179,14 +198,15 @@ impl<T> ReadQueue<T> {
 }
 
 pub struct WriteQueue<T> {
-    #[cfg(not(all(feature = "monoio", feature = "tpc")))]
-    inner: Arc<Mutex<WriteQueueInner<T>>>,
-    #[cfg(all(feature = "monoio", feature = "tpc"))]
-    inner: Rc<UnsafeCell<WriteQueueInner<T>>>,
-    #[cfg(not(all(feature = "monoio", feature = "tpc")))]
-    working_notifier: Arc<Notifier>,
-    #[cfg(all(feature = "monoio", feature = "tpc"))]
-    working_notifier: Rc<Notifier>,
+    inner: SharedInner<T>,
+    working_notifier: SharedNotifier,
+    // Stop-signal receiver for the unstuck handler, shared by all clones of
+    // this handle. The handler task itself does not hold it, so dropping the
+    // last WriteQueue clone releases the receiver and the handler observes
+    // the closed channel and exits. (Keeping the receiver inside the shared
+    // inner state — which the handler holds alive — would make the stop
+    // branch unreachable and leak the handler task.)
+    guard: SharedGuard,
 }
 
 impl<T> Clone for WriteQueue<T> {
@@ -194,6 +214,7 @@ impl<T> Clone for WriteQueue<T> {
         Self {
             inner: self.inner.clone(),
             working_notifier: self.working_notifier.clone(),
+            guard: self.guard.clone(),
         }
     }
 }
@@ -313,14 +334,22 @@ impl<T> WriteQueue<T> {
         PushResult::Pending(PushJoinHandle { waker_slot })
     }
 
-    async fn unstuck_handler(self, mut unstuck_awaiter: Awaiter, mut tx: Sender<()>) {
+    // The handler takes the shared state explicitly instead of a WriteQueue
+    // clone so that it never holds the stop-signal receiver (see the
+    // `guard` field).
+    async fn unstuck_handler(
+        inner: SharedInner<T>,
+        working_notifier: SharedNotifier,
+        mut unstuck_awaiter: Awaiter,
+        mut tx: Sender<()>,
+    ) {
         let mut exit = std::pin::pin!(tx.closed());
         loop {
             {
                 #[cfg(not(all(feature = "monoio", feature = "tpc")))]
-                let mut inner = self.inner.lock();
+                let mut inner = inner.lock();
                 #[cfg(all(feature = "monoio", feature = "tpc"))]
-                let inner = unsafe { &mut *self.inner.get() };
+                let inner = unsafe { &mut *inner.get() };
 
                 while let Some(mut pending_task) = inner.pending_tasks.pop_front() {
                     let data = pending_task.data.take().unwrap();
@@ -344,7 +373,7 @@ impl<T> WriteQueue<T> {
                 }
                 if !inner.queue.working() {
                     inner.queue.mark_working();
-                    let _ = self.working_notifier.notify();
+                    let _ = working_notifier.notify();
                 }
                 if !inner.pending_tasks.is_empty() {
                     inner.queue.mark_stuck();
@@ -367,7 +396,6 @@ impl<T> WriteQueue<T> {
 pub struct WriteQueueInner<T> {
     queue: Queue<T>,
     pending_tasks: VecDeque<PendingTask<T>>,
-    _guard: Receiver<()>,
 }
 
 impl<T> WriteQueue<T> {
@@ -464,6 +492,22 @@ unsafe impl<T: Sync> Sync for Queue<T> {}
 
 impl<T> Queue<T> {
     pub fn new(size: usize) -> Result<(Self, QueueMeta), io::Error> {
+        // Create both fd pairs before leaking any memory, so a failure here
+        // leaks nothing. If the second pair fails, close the first one.
+        let (working_fd, working_fd_peer) = new_pair()?;
+        let (unstuck_fd, unstuck_fd_peer) = match new_pair() {
+            Ok(pair) => pair,
+            Err(e) => {
+                unsafe {
+                    libc::close(working_fd);
+                    libc::close(working_fd_peer);
+                }
+                return Err(e);
+            }
+        };
+
+        // From here on nothing can fail: allocation failures abort, so the
+        // leaked memory is always reclaimed by `Drop` once it exists.
         let buffer = unsafe {
             let mut v = Vec::<MaybeUninit<T>>::with_capacity(size);
             v.set_len(size);
@@ -475,9 +519,6 @@ impl<T> Queue<T> {
         let tail_ptr = Box::leak(Box::new(AtomicU64::new(0)));
         let working_ptr = Box::leak(Box::new(AtomicU32::new(0)));
         let stuck_ptr = Box::leak(Box::new(AtomicU32::new(0)));
-
-        let (working_fd, working_fd_peer) = new_pair()?;
-        let (unstuck_fd, unstuck_fd_peer) = new_pair()?;
 
         let queue = Self {
             buffer_ptr: buffer_slice.as_mut_ptr(),
@@ -592,26 +633,36 @@ impl<T> Queue<T> {
         let unstuck_awaiter = unsafe { Awaiter::from_raw_fd(unstuck_fd)? };
 
         let (tx, rx) = channel();
+        #[cfg(feature = "tpc")]
+        let inner = Rc::new(UnsafeCell::new(WriteQueueInner {
+            queue: self,
+            pending_tasks: VecDeque::new(),
+        }));
+        #[cfg(not(feature = "tpc"))]
+        let inner = Arc::new(Mutex::new(WriteQueueInner {
+            queue: self,
+            pending_tasks: VecDeque::new(),
+        }));
+        #[cfg(feature = "tpc")]
+        let working_notifier = Rc::new(working_notifier);
+        #[cfg(not(feature = "tpc"))]
+        let working_notifier = Arc::new(working_notifier);
+        #[cfg(feature = "tpc")]
+        let guard = Rc::new(rx);
+        #[cfg(not(feature = "tpc"))]
+        let guard = Arc::new(rx);
         let wq = WriteQueue {
-            #[cfg(feature = "tpc")]
-            inner: Rc::new(UnsafeCell::new(WriteQueueInner {
-                queue: self,
-                pending_tasks: VecDeque::new(),
-                _guard: rx,
-            })),
-            #[cfg(not(feature = "tpc"))]
-            inner: Arc::new(Mutex::new(WriteQueueInner {
-                queue: self,
-                pending_tasks: VecDeque::new(),
-                _guard: rx,
-            })),
-            #[cfg(feature = "tpc")]
-            working_notifier: Rc::new(working_notifier),
-            #[cfg(not(feature = "tpc"))]
-            working_notifier: Arc::new(working_notifier),
+            inner,
+            working_notifier,
+            guard,
         };
 
-        spawn(wq.clone().unstuck_handler(unstuck_awaiter, tx));
+        spawn(WriteQueue::unstuck_handler(
+            wq.inner.clone(),
+            wq.working_notifier.clone(),
+            unstuck_awaiter,
+            tx,
+        ));
 
         Ok(wq)
     }
@@ -633,12 +684,17 @@ impl<T> Queue<T> {
             inner: Arc::new(Mutex::new(WriteQueueInner {
                 queue: self,
                 pending_tasks: VecDeque::new(),
-                _guard: rx,
             })),
             working_notifier: Arc::new(working_notifier),
+            guard: Arc::new(rx),
         };
 
-        spawn(wq.clone().unstuck_handler(unstuck_awaiter, tx));
+        spawn(WriteQueue::unstuck_handler(
+            wq.inner.clone(),
+            wq.working_notifier.clone(),
+            unstuck_awaiter,
+            tx,
+        ));
 
         Ok(wq)
     }
@@ -663,12 +719,17 @@ impl<T> Queue<T> {
             inner: Arc::new(Mutex::new(WriteQueueInner {
                 queue: self,
                 pending_tasks: VecDeque::new(),
-                _guard: rx,
             })),
             working_notifier: Arc::new(working_notifier),
+            guard: Arc::new(rx),
         };
 
-        tokio_handle.spawn(wq.clone().unstuck_handler(unstuck_awaiter, tx));
+        tokio_handle.spawn(WriteQueue::unstuck_handler(
+            wq.inner.clone(),
+            wq.working_notifier.clone(),
+            unstuck_awaiter,
+            tx,
+        ));
 
         Ok(wq)
     }
@@ -991,6 +1052,50 @@ mod tests {
                 sleep(Duration::from_millis(20)).await;
             }
             assert_eq!(got, vec![2, 3]);
+            assert!(q_read.pop().is_none());
+        }
+
+        async fn unstuck_handler_stops_after_write_queue_drop() {
+            // The READ side owns the shared memory here: dropping the last
+            // WriteQueue clone stops the unstuck handler, which drops the
+            // write-side queue; if that queue owned the memory, the buffer
+            // would be freed while the read queue still points at it
+            // (use-after-free).
+            let (q_read, meta) = Queue::<u32>::new(1).unwrap();
+            let q_write = unsafe { Queue::<u32>::new_from_meta(&meta) }.unwrap();
+            let mut q_read = q_read.read();
+            let q_write = q_write.write().unwrap();
+
+            // One slot, two items: the second goes into pending tasks.
+            assert!(q_write.push(1));
+            assert!(!q_write.push(2));
+            // This pop notifies the unstuck handler, which flushes the
+            // pending item while the write queue is still alive.
+            assert_eq!(q_read.pop(), Some(1));
+            let mut got = None;
+            for _ in 0..50 {
+                if let Some(v) = q_read.pop() {
+                    got = Some(v);
+                    break;
+                }
+                sleep(Duration::from_millis(20)).await;
+            }
+            assert_eq!(got, Some(2));
+
+            // Re-fill: one item in the queue, one pending. No pop follows,
+            // so the handler stays parked in its wait until it is stopped.
+            assert!(q_write.push(3));
+            assert!(!q_write.push(4));
+
+            // Dropping the last WriteQueue clone releases the stop-signal
+            // receiver; the handler observes the closed channel and exits.
+            drop(q_write);
+            sleep(Duration::from_millis(100)).await;
+
+            // The notify from this pop reaches no one: the remaining pending
+            // item must never be flushed.
+            assert_eq!(q_read.pop(), Some(3));
+            sleep(Duration::from_millis(100)).await;
             assert!(q_read.pop().is_none());
         }
 

--- a/rust2go-mem-ffi/src/lib.rs
+++ b/rust2go-mem-ffi/src/lib.rs
@@ -127,6 +127,17 @@ pub unsafe fn init_mem_ffi<const N: usize>(
             }
         })
         .expect("unable to run ffi handler");
+    // Intentionally leaked: init_mem_ffi runs once per thread and the
+    // read-side handler must stay alive for the whole process lifetime, so
+    // its stop-signal guard is never dropped.
+    //
+    // Note the handler closure above also holds a clone of the write queue
+    // (`wq`) to push drop-ack payloads. That clone lives as long as the
+    // handler — i.e. forever — so on this FFI path the write queue's
+    // stop-signal receiver is never released either and the write-side
+    // unstuck handler does not exit on drop. This is by design for the FFI
+    // use case; the write-queue stop mechanism only takes effect when all
+    // WriteQueue clones are actually dropped.
     Box::leak(Box::new(guard));
     (write_queue, shared_slab)
 }


### PR DESCRIPTION
## What

### 1. Write-side unstuck handler stop mechanism was dead code (reference cycle)

The stop-signal receiver lived inside `WriteQueueInner`, and the spawned `unstuck_handler` task held a `WriteQueue` clone — hence the shared inner state, hence the receiver. `tx.closed()` could never fire, the exit branch was unreachable, and the handler task leaked until runtime exit.

Fix: the receiver moves out of `WriteQueueInner` into `WriteQueue` as a `SharedGuard` (`Arc<Receiver>`, or `Rc<Receiver>` under monoio+tpc) shared only by user-side clones. `unstuck_handler` now takes the shared inner state and working notifier as plain parameters and never holds the receiver. Dropping the **last** `WriteQueue` clone releases the receiver, closes the channel, and the handler exits — dropping the inner queue, its fds, and (when it is the owner) the shared memory. Both cfg variants (monoio+tpc `Rc<UnsafeCell>`, everything else `Arc<Mutex>`) are updated consistently; new `SharedInner`/`SharedNotifier`/`SharedGuard` type aliases remove the per-field cfg duplication.

Regression test `unstuck_handler_stops_after_write_queue_drop` (runs under both monoio and tokio legs): after the last `WriteQueue` clone is dropped, a later pop's unstuck notification must not flush the remaining pending item. It fails on the old code (the still-alive handler would flush item 4) and passes on the new.

### 2. `Queue::new` error-path leak

Both socketpairs are now created before any `Box::leak`, and the first pair's fds are closed if the second `new_pair()` fails. Previously a socketpair failure permanently leaked the buffer, the four atomic boxes, and (on second-pair failure) the first fd pair.

### 3. `init_mem_ffi` intentional-leak documentation

The `Box::leak(Box::new(guard))` is by design (once-per-thread FFI init; the read handler must live for the process lifetime), but was undocumented. Comments now explain the intent and the interaction with fix 1: the handler closure holds a `WriteQueue` clone forever (for drop-ack payloads), so the write-side handler never observes the stop signal on the FFI path.

### 4. Self-contained committed files

`codecov.yml` and `docs/ci.md` no longer reference task numbers or the uncommitted planning file; the unstuck stop-branch miss is removed from the coverage-gap list because the branch is now live and covered by the new test. `mem-ring/README.md` gains a Rust-side stop-semantics section including the `init_mem_ffi` exception.

## Notes

- Pre-existing gap (not introduced here, flagged for follow-up): CI never compiles mem-ring with monoio-but-not-tpc, so the `not(tpc)` monoio blocks are verified by inspection only.
- codecov.yml validated with the official Codecov validator.