### PR TITLE
docs: record refactor milestones, sync docs, cover mem-ring monoio-no-tpc in CI (task 4.8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,13 @@ jobs:
         run: |
           cargo test -p mem-ring --all-targets
           cargo test -p mem-ring --no-default-features --features tokio --all-targets
+      # The documented "monoio without tpc" configuration (multi-thread
+      # producers sharing one queue, see mem-ring/Cargo.toml) is never
+      # compiled by any of the runs above: the workspace build unifies
+      # mem-ring's default features, which always include tpc. Compile it
+      # standalone so the supported combination cannot silently break.
+      - name: Build mem-ring (monoio, no tpc)
+        run: cargo check -p mem-ring --no-default-features --features monoio --all-targets
       # Building the workspace above regenerates the committed Go bindings
       # (test/go/gen.go, examples/example-bidirectional/go/gen.go) via
       # build.rs scripts; fail if the committed copies have drifted from

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 
 Rust2Go is a project that provides users with a simple and efficient way to call Golang from Rust with native async support. It also support user calling Rust from Golang.
 
+## Blogs
+
+- [Design and Implementation of a Rust-Go FFI Framework](https://en.ihcblog.com/rust2go/) by [@ihciah](https://github.com/ihciah): the overall design of rust2go — solution selection, parameter/return-value passing, and async support.
+- [Rust2Go Part2: Exploring CGO Calls for Extreme Performance](https://en.ihcblog.com/rust2go-cgo-asm/) by [@ihciah](https://github.com/ihciah): replacing CGO with hand-written assembly — the G0 stack, async preemption, and benchmarks.
+- [Refactoring rust2go: One Month, Twenty Small PRs](https://lirenjie95.github.io/posts/rust2go-refactor.html) by [@lirenjie95](https://github.com/lirenjie95): a retrospective on the month-long refactor of the whole repository — safety nets, codegen restructuring, CI hardening, and the bugs found along the way.
+
 ## Features
 
 - Sync and async calls from Rust to Golang
@@ -93,6 +99,17 @@ Note: Since golang may scan the stack, and when it meets peer pointer, it may pa
 ### Extended Features
 
 - [x] Support calling rust from golang
+
+### Engineering & Maintainability
+
+- [x] Codegen restructured: one primitive-type table shared by all emitters, ir/emit layering for both call directions, and Go templates as standalone `.go.tmpl` files
+- [x] `generate()` extracted into the `rust2go-gen` library crate; the CLI is a thin shell over it
+- [x] Macro errors reported as spanned `syn::Error` diagnostics instead of compiler panics
+- [x] mem-ring hardened: error returns instead of dead loops, stop mechanisms for background goroutines/tasks, fd ownership and error-path leak fixes
+- [x] Examples deduplicated onto a shared demo template, with CI sync/freshness checks
+- [x] CI: pinned Go toolchains (1.18 minimum + stable), `gofmt`/`go vet` gates, and linux/macOS/Windows coverage across amd64 and arm64 legs
+- [x] Code coverage introduced and gated (project target 97%)
+- [x] Documentation overhauled to match the code: build script reference, attribute reference, CI guide, and per-package READMEs
 
 ## Coverage
 

--- a/asmcall/README_ZH.md
+++ b/asmcall/README_ZH.md
@@ -49,7 +49,7 @@ ok      github.com/ihciah/rust2go/asmcall/bench 4.055s
 
 但这并不代表 CGO 的实现一定很糟糕，我认为这是做了一些权衡的结果。对于较简单的 C/Rust 函数，使用 ASM 很合适；而如果是耗时较长的外部函数，使用这种方式会导致 Go 无法异步抢占，线程上的 goroutines 调度延迟增大，影响整个系统的延迟。
 
-如需测量在其他环境下的性能表现，可以使用 `go test -bench .` 运行本 package 附带的 benchmark 代码。
+如需测量在其他环境下的性能表现，可以在 `/asmcall/bench` 目录下使用 `go test -bench .` 运行本 package 附带的 benchmark 代码。
 
 ## 独立使用方式
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -49,7 +49,7 @@ The two `-mem` examples enable opposite runtimes of `rust2go-mem-ffi` (`example-
 
 - Workspace-wide commands exclude `example-tokio-mem` (and use default features elsewhere).
 - `example-tokio-mem` and the tokio branch of `rust2go-mem-ffi` are checked/tested/linted in dedicated steps (`-p ... --no-default-features --features tokio`).
-- `mem-ring` is tested twice: default features (monoio) and `--no-default-features --features tokio`.
+- `mem-ring` is tested twice: default features (monoio + tpc) and `--no-default-features --features tokio`. The third documented configuration — monoio **without** `tpc` (multi-thread producers sharing one queue) — is compiled standalone (`cargo check`), because the workspace build always unifies in the default `tpc` feature and would never reach that cfg combination.
 - `rust2go`'s optional `build` feature (bindgen/cbindgen machinery) is checked and linted in its own step.
 
 A side effect of the split: the tokio branches of `rust2go-mem-ffi` are actually compiled in CI now — under `--all-features` they were always cfg'd out.


### PR DESCRIPTION
## What

Final wrap-up of the refactor:

- **README**: new **Blogs** section (two design posts by @ihciah + the refactor retrospective by @lirenjie95) and an **Engineering & Maintainability** milestone subsection reflecting what the refactor actually delivered (codegen restructure, rust2go-gen extraction, spanned `syn::Error` diagnostics, mem-ring hardening, examples dedup, CI hardening, 97% coverage gate, docs overhaul).
- **CI**: new step compiles mem-ring's documented **monoio-without-tpc** configuration (`cargo check -p mem-ring --no-default-features --features monoio --all-targets`). This closes the gap noted during #192 review: workspace builds always unify in mem-ring's default `tpc` feature, so this supported combination was never compiled in CI.
- **docs/ci.md**: the feature-matrix section now documents all three mem-ring configurations and why the third needs a standalone check.
- **asmcall/README_ZH**: points readers at the actual benchmark directory (`/asmcall/bench`).

## Notes

- Docs-only + one CI step; no code behavior changes.
- The third blog link (lirenjie95.github.io) goes live when the blog repo is published; publication is coordinated alongside this PR.
- Pre-commit independent review loop passed (2 passes, no actionable findings; all milestone claims verified against repo state).

Co-authored-by: ihciah <ihciah@gmail.com>