### PR TITLE
docs: fill in mem-ring "How it Works" section

### DIFF
--- a/mem-ring/README.md
+++ b/mem-ring/README.md
@@ -7,7 +7,29 @@ With 2 rings, users can simulate calls between rust and go(Both sides can start 
 The Go package (`mem-ring`) is unix-only: it relies on `x/sys/unix` and socketpair fds, and does not compile on Windows. The unix GOOS set is spelled out in the build constraints (`aix || android || darwin || ...`) instead of the `unix` tag, which Go only recognizes since 1.19 — the package builds with the Go 1.18 minimum toolchain declared in the root `go.mod`.
 
 ## How it Works
-TODO
+
+Each ring is a SPSC queue living in memory shared by Rust and Go (both languages are linked into one process, so "shared memory" is just the common address space). A ring consists of a fixed-size slot buffer plus four atomics: `head`, `tail`, `working` and `stuck`. The producer writes a slot and bumps `tail`; the consumer reads a slot and bumps `head`, both with acquire/release ordering — there is no lock on the data path.
+
+One side creates a ring with `Queue::new(size)`, which allocates the buffer and the atomics and returns a `QueueMeta` next to the queue. `QueueMeta` is a plain `#[repr(C)]` struct carrying the raw addresses (as `usize`/`uintptr`) and the peer ends of two socketpairs; passing it to the other language lets that side reconstruct a view of the same ring (`Queue::new_from_meta` on Rust, `NewQueue` on Go). The creator owns the memory and frees it on drop; the side built from the meta owns only the fds it received. (Materializing pointers from raw integers trips `go vet`'s unsafeptr analyzer, which is why CI runs vet with `-unsafeptr=false`.)
+
+Polling alone would burn CPU, so each ring also carries two unix socketpairs for notification (the module is called `eventfd`, but it is implemented with `socketpair(AF_UNIX, SOCK_STREAM)`, nonblocking where the OS supports it). A `Notifier` writes a single byte; an `Awaiter` performs one read:
+
+- **working fd** (writer → reader): "there are new items". The writer notifies only on the idle→working transition (the `working` flag), so under load many pushes are aggregated into few syscalls.
+- **unstuck fd** (reader → writer): "I drained the ring". When the ring is full, the writer sets `stuck` and parks overflow items in a local pending queue; a background unstuck handler flushes them into the ring each time it is woken.
+
+```
+        one ring = slot buffer + head/tail/working/stuck atomics + 2 socketpairs
+
+ writer ── push slot, bump tail ──► [ ring buffer ] ── pop slot, bump head ──► reader
+ writer ─────── working fd: 1 byte, "new items" ───────────────────────────► reader
+ writer ◄────── unstuck fd: 1 byte, "ring drained" ───────────────────────── reader
+```
+
+The read-side handler drains the ring, then yields a few times before sleeping (three `yield_now` rounds on Rust; a `TinyWaiter` on Go, `GoSchedWaiter` by default) to catch pushes racing with the sleep transition, clears `working`, and blocks on the working fd until the peer notifies.
+
+A bidirectional channel is just two independent rings, crossed: each side holds the write half of one ring and the read half of the other, so both Rust and Go can initiate calls. `rust2go-mem-ffi::init_mem_ffi` shows the pattern — `init_rings` creates both rings, hands the two `QueueMeta`s to the peer through its init function, and keeps one `ReadQueue` and one `WriteQueue`. In-flight call state is kept per side in a slab (Go: `MultiSlab`; Rust: `slab::Slab<TaskDesc>`) — an index-keyed local store, not a shared-memory allocator; the indices travel inside `Payload.user_data`/`next_user_data`, and `DROP` payloads tell the peer to release its slot.
+
+On the Rust side the `monoio` (default) and `tokio` features select the same loop structure with different primitives: monoio spawns the handlers on the current thread and uses `local-sync` channels, while tokio uses its own oneshot/spawn with `Send` bounds (the `read_with_tokio_handle`/`write_with_tokio_handle` variants let you pick the runtime). With `monoio + tpc` (the default) the write-side state is `Rc<UnsafeCell>` — single-threaded, lock-free, one queue per thread; without `tpc` it is `Arc<Mutex>` so `WriteQueue` clones can be shared across threads at the cost of lock contention.
 
 ## How to Choose Mode for Rust
 


### PR DESCRIPTION
Replaces the long-standing `TODO` in `mem-ring/README.md` with an architecture description verified against the current sources:

- SPSC ring structure: fixed-size slot buffer with `head`/`tail`/`working`/`stuck` atomics (acquire/release, lock-free data path)
- `QueueMeta` layout and ownership rules (creator owns the shared memory; the peer side only owns the fds), which is also why the Go module needs `go vet -unsafeptr=false`
- The two socketpair notification channels per ring: the working fd (idle→working edge-triggered notify to aggregate syscalls) and the unstuck fd (writer marks `stuck` on a full ring and parks overflow items into a local pending queue, flushed by the background unstuck handler)
- Reader yield strategies before sleeping: Rust `yield_now` x3, Go `TinyWaiter` (default `GoSchedWaiter`)
- Bidirectional calls = two crossed rings, referencing `rust2go-mem-ffi::init_mem_ffi`/`init_rings`
- monoio (default) vs tokio runtime differences, and the `tpc` (thread-per-core) write-side state layout

Docs-only change (`mem-ring/README.md`, +23/-1). CI already verified green on this branch (workflow_dispatch run 34568648506).